### PR TITLE
Fix result proxy close method

### DIFF
--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql.dml import UpdateBase
 from sqlalchemy.sql.ddl import DDLElement
 
 from . import exc
-from .result import ResultProxy
+from .result import create_result_proxy
 from .transaction import (RootTransaction, Transaction,
                           NestedTransaction, TwoPhaseTransaction)
 
@@ -104,7 +104,7 @@ class SAConnection:
                                     "SQLAlchemy data "
                                     "selection/modification clause")
 
-        ret = ResultProxy(self, cursor, self._dialect)
+        ret = yield from create_result_proxy(self, cursor, self._dialect)
         self._weak_results.add(ret)
         return ret
 

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -228,12 +228,6 @@ class ResultProxy:
         self._rowcount = cursor.rowcount
         self._lastrowid = cursor.lastrowid
 
-        if cursor.description is not None:
-            self._metadata = ResultMetaData(self, cursor.description)
-            # self._weak = weakref.ref(self, lambda wr: cursor.close())
-        else:
-            self._metadata = None
-
     @asyncio.coroutine
     def _prepare(self):
         cursor = self._cursor

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -230,10 +230,12 @@ class ResultProxy:
 
     @asyncio.coroutine
     def _prepare(self):
+        loop = self._connection.connection.loop
         cursor = self._cursor
         if cursor.description is not None:
             self._metadata = ResultMetaData(self, cursor.description)
-            self._weak = weakref.ref(self, lambda wr: cursor.close())
+            callback = lambda wr: asyncio.Task(cursor.close(), loop=loop)
+            self._weak = weakref.ref(self, callback)
         else:
             self._metadata = None
             yield from self.close()

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -307,10 +307,10 @@ class TestSAConnection(unittest.TestCase):
         def go():
             conn = yield from self.connect()
             res = yield from conn.execute("SELECT 1")
-            res.close()
+            yield from res.close()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
-            res.close()
+            yield from res.close()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
 
@@ -356,7 +356,7 @@ class TestSAConnection(unittest.TestCase):
             yield from conn.execute(tbl.insert().values(name='second'))
 
             res = yield from conn.execute(tbl.select())
-            res.close()
+            yield from res.close()
             with self.assertRaises(sa.ResourceClosedError):
                 yield from res.fetchall()
 
@@ -379,7 +379,7 @@ class TestSAConnection(unittest.TestCase):
             yield from conn.execute(tbl.insert().values(name='second'))
 
             res = yield from conn.execute(tbl.select())
-            res.close()
+            yield from res.close()
             with self.assertRaises(sa.ResourceClosedError):
                 yield from res.fetchone()
 
@@ -432,7 +432,7 @@ class TestSAConnection(unittest.TestCase):
             yield from conn.execute(tbl.insert().values(name='second'))
 
             res = yield from conn.execute(tbl.select())
-            res.close()
+            yield from res.close()
             with self.assertRaises(sa.ResourceClosedError):
                 yield from res.fetchmany()
 
@@ -445,7 +445,7 @@ class TestSAConnection(unittest.TestCase):
             yield from conn.execute(tbl.insert().values(name='second'))
 
             res = yield from conn.execute(tbl.select())
-            res.close()
+            yield from res.close()
             with self.assertRaises(sa.ResourceClosedError):
                 yield from res.fetchmany(5555)
 


### PR DESCRIPTION
In ``ResultProxy`` class ``cursor.close()`` called without `` yield from`` since ``cursor.close`` is coroutine ``ResultProxy.close`` must be coroutine too. This PR fixes this issue and all warnings in travisci like:
```
<CoroWrapper Cursor.close() running at /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/aiomysql/cursors.py:148, 
created at /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/aiomysql/sa/result.py:322> was never yielded from
```
see this [travis bulild]( https://travis-ci.org/aio-libs/aiomysql/jobs/60567222).

But I do not know proper way how to fix following line:
```python
self._weak = weakref.ref(self, lambda wr: cursor.close())
```
may be with ``asyncio.Task``:
```python
self._weak = weakref.ref(self, lambda wr: asyncio.Task(cursor.close(), loop=self._loop))
```
??

Please review.