### PR TITLE
Close old socket before reconnect

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -422,6 +422,10 @@ class Connection:
         # TODO: Set close callback
         # raise OperationalError(2006,
         # "MySQL server has gone away (%r)" % (e,))
+
+        # Close the previous transport if any:
+        self.close()
+
         try:
             if self._unix_socket and self._host in ('localhost', '127.0.0.1'):
                 self._reader, self._writer = yield from \

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -161,7 +161,7 @@ class TestConnection(AIOPyMySQLTestCase):
         with self.assertRaises(aiomysql.OperationalError) as cm:
             yield from cur.execute("SELECT 1+1")
         # error occures while reading, not writing because of socket buffer.
-        # self.assertEquals(cm.exception.args[0], 2006)
+        # self.assertEqual(cm.exception.args[0], 2006)
         self.assertIn(cm.exception.args[0], (2006, 2013))
         conn.close()
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -203,7 +203,7 @@ class TestCursor(base.AIOPyMySQLTestCase):
         yield from cur.execute('SELECT * FROM tbl;')
         yield from cur.scroll(1)
         ret = yield from cur.fetchall()
-        self.assertEquals(((2, 'b'), (3, 'c')), ret)
+        self.assertEqual(((2, 'b'), (3, 'c')), ret)
 
     @run_until_complete
     def test_aggregates(self):
@@ -250,7 +250,7 @@ class TestCursor(base.AIOPyMySQLTestCase):
         self.assertEqual(row_count, 3)
         r = yield from cur.fetchall()
         # TODO: if this right behaviour
-        self.assertEquals(((3, 'c'),),  r)
+        self.assertEqual(((3, 'c'),),  r)
 
         # calling execute many without args
         row_count = yield from cur.executemany('SELECT 1;', ())


### PR DESCRIPTION
Current implementation doesn't close transport before reconnect (in `connection.ping` for example). It left sockets opened.