### PR TITLE
Update docs

### DIFF
--- a/docs/pool.rst
+++ b/docs/pool.rst
@@ -91,11 +91,6 @@ The basic usage is::
 
         A count of free connections in the pool (*readonly*).
 
-    .. attribute:: timeout
-
-        A read-only float representing default timeout for operations
-        for connections from pool.
-
     .. method:: clear()
 
        A :ref:`coroutine <coroutine>` that closes all *free* connections

--- a/docs/sa.rst
+++ b/docs/sa.rst
@@ -69,7 +69,7 @@ Engine
 ------
 
 .. function:: create_engine(*, minsize=10, maxsize=10, loop=None, \
-                            dialect=dialect, timeout=60, **kwargs)
+                            dialect=dialect, **kwargs)
 
     A :ref:`coroutine <coroutine>` for :class:`Engine` creation.
 
@@ -127,11 +127,6 @@ Engine
     .. attribute:: freesize
 
         A count of free connections in the pool (*readonly*).
-
-    .. attribute:: timeout
-
-        A read-only float representing default timeout for operations
-        for connections from pool.
 
     .. method:: close()
 


### PR DESCRIPTION
Remove 'timeout' attribute and parameter from sa.create_engine
and 'timeout' attribute from aiomysql.create_pool method because
they don't exist in source code.