### PR TITLE
Raise exception if previous cursor was not closed

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -372,6 +372,9 @@ class Connection:
     @asyncio.coroutine
     def query(self, sql, unbuffered=False):
         # logger.debug("DEBUG: sending query: %s", _convert_to_str(sql))
+        if self._result is not None and self._result.has_next:
+            raise ProgrammingError("Previous results have not been fetched. "
+                                   "You may not close previous cursor.")
         if isinstance(sql, str):
             sql = sql.encode(self.encoding, 'surrogateescape')
         yield from self._execute_command(COM_QUERY, sql)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -243,3 +243,12 @@ class TestConnection(AIOPyMySQLTestCase):
         conn = yield from self.connect()
         self.assertTrue(conn._no_delay)
         conn.close()
+
+    @run_until_complete
+    def test_previous_cursor_not_closed(self):
+        conn = yield from self.connect()
+        cur1 = yield from conn.cursor()
+        yield from cur1.execute("SELECT 1; SELECT 2")
+        cur2 = yield from conn.cursor()
+        with self.assertRaises(aiomysql.ProgrammingError):
+            yield from cur2.execute("SELECT 3")


### PR DESCRIPTION
Fix ported from https://github.com/PyMySQL/PyMySQL/pull/403