### PR TITLE
Added connection corruption test, when cancelling cursor.

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -39,7 +39,8 @@ from pymysql.connections import LoadLocalPacketWrapper
 
 # from aiomysql.utils import _convert_to_str
 from .cursors import Cursor
-from .utils import PY_35, _ConnectionContextManager, _ContextManager
+from .utils import (
+    PY_35, _ConnectionContextManager, _ContextManager, shield_wait)
 # from .log import logger
 
 DEFAULT_USER = getpass.getuser()
@@ -505,6 +506,12 @@ class Connection:
 
     @asyncio.coroutine
     def _read_query_result(self, unbuffered=False):
+        yield from shield_wait(
+            self._read_query_result_impl(unbuffered),
+            loop=self._loop)
+
+    @asyncio.coroutine
+    def _read_query_result_impl(self, unbuffered=False):
         if unbuffered:
             try:
                 result = MySQLResult(self)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -307,6 +307,6 @@ class TestCursor(base.AIOPyMySQLTestCase):
         names = [x[0] for x in cur2.description]
         # If we receive ["id", "xxx"] - we corrupted the connection
         self.assertEqual(names, ["value", "xxx"])
-        res = yield from cur2.fetchone()
+        res = yield from cur2.fetchall()
         # If we receive [(1, 0)] - we retrieved old cursor's values
         self.assertEqual(list(res), [(2, 0)])

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -286,3 +286,27 @@ class TestCursor(base.AIOPyMySQLTestCase):
                     "INSERT INTO tbl VALUES(2, 'b')",
                     "INSERT INTO tbl VALUES(3, 'c')"]
         self.assertEqual(results, expected)
+
+    @run_until_complete
+    def test_execute_cancel(self):
+        conn = self.connections[0]
+        cur = yield from conn.cursor()
+        # Cancel a cursor in the middle of execution, before it could
+        # read even the first packet (SLEEP assures the timings)
+        task = self.loop.create_task(cur.execute(
+            "SELECT 1 as id, SLEEP(0.1) as xxx"))
+        yield from asyncio.sleep(0.05, loop=self.loop)
+        task.cancel()
+        try:
+            yield from task
+        except asyncio.CancelledError:
+            pass
+
+        cur2 = yield from conn.cursor()
+        yield from cur2.execute("SELECT 2 as value, 0 as xxx")
+        names = [x[0] for x in cur2.description]
+        # If we receive ["id", "xxx"] - we corrupted the connection
+        self.assertEqual(names, ["value", "xxx"])
+        res = yield from cur2.fetchone()
+        # If we receive [(1, 0)] - we retrieved old cursor's values
+        self.assertEqual(list(res), [(2, 0)])


### PR DESCRIPTION
Don't merge this yet. We need to agree how to fix it. Maybe add another test for connections to not return into Pool after cancellation.