### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ aiomysql
     :target: https://badge.fury.io/py/aiomysql
     :alt: Latest Version
 .. image:: https://readthedocs.org/projects/aiomysql/badge/?version=latest
-    :target: http://aiomysql.readthedocs.org/
+    :target: https://aiomysql.readthedocs.io/
     :alt: Documentation Status
 
 **aiomysql** is a "driver" for accessing a `MySQL` database
@@ -23,7 +23,7 @@ proper places)). `sqlalchemy` support ported from aiopg_.
 
 Documentation
 -------------
-http://aiomysql.readthedocs.org/
+https://aiomysql.readthedocs.io/
 
 
 Mailing List


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.