### PR TITLE
To avoid AttributeError in function _request_authentication(self)

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -209,6 +209,8 @@ class Connection:
         # user
         self._close_reason = None
 
+        self._auth_plugin_name = ""
+
     @property
     def host(self):
         """MySQL server IP address or name"""
@@ -756,6 +758,7 @@ class Connection:
             i += salt_len
 
         i += 1
+
         # AUTH PLUGIN NAME may appear here.
         if self.server_capabilities & CLIENT.PLUGIN_AUTH and len(data) >= i:
             # Due to Bug#59453 the auth-plugin-name is missing the terminating


### PR DESCRIPTION
Hi,

When I use aiomysql 0.0.8 on Window10 x64 using Python3.5.2 to connect mysql server( version 5.1.73) on Centos6.4 x64, I got:

  _File "G:\git\aiowebapp\.env\lib\site-packages\aiomysql\connection.py", line 657, in _request_authentication
    if self._auth_plugin_name in ('', 'mysql_native_password'):
AttributeError: 'Connection' object has no attribute '_auth_plugin_name'_

I checked the Server Greeting wirshark cap, found the "PLUGIN_AUTH" bit in "server capabilities" is 0, which means "self.server_capabilities & CLIENT.PLUGIN_AUTH" is False in function "_get_server_information(self)",  so attribute '_auth_plugin_name_' is undefined here.
And then the "AttributeError" occur in  `_request_authentication(self):
    if self.server_capabilities & CLIENT.PLUGIN_AUTH:`

And when I do this fix, the aiomysql works well!

Best Regards
Mingming