### PR TITLE
proper argument for cursor.execute (for sa engine)

### DIFF
--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -74,7 +74,7 @@ class SAConnection:
             dp = dp[0]
 
         if isinstance(query, str):
-            yield from cursor.execute(query, dp)
+            yield from cursor.execute(query, dp or None)
         elif isinstance(query, ClauseElement):
             compiled = query.compile(dialect=self._dialect)
             # parameters = compiled.params

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -290,6 +290,13 @@ class TestSAConnection(unittest.TestCase):
                     [(2, 'third'), (3, 'forth')])
         self.loop.run_until_complete(go())
 
+    def test_raw_select_with_wildcard(self):
+        @asyncio.coroutine
+        def go():
+            conn = yield from self.connect()
+            yield from conn.execute('SELECT * FROM sa_tbl WHERE name LIKE "%test%"')
+        self.loop.run_until_complete(go())
+
     def test_delete(self):
         @asyncio.coroutine
         def go():

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -294,7 +294,8 @@ class TestSAConnection(unittest.TestCase):
         @asyncio.coroutine
         def go():
             conn = yield from self.connect()
-            yield from conn.execute('SELECT * FROM sa_tbl WHERE name LIKE "%test%"')
+            yield from conn.execute(
+                'SELECT * FROM sa_tbl WHERE name LIKE "%test%"')
         self.loop.run_until_complete(go())
 
     def test_delete(self):


### PR DESCRIPTION
For the SQLAlchemy engine, the `_distill_params` function in `sa/connection.py` returns an empty list [] when no arguments are passed.

This results in [] passed to cursor.execute as the `args` argument causing if check 
https://github.com/aio-libs/aiomysql/blob/master/aiomysql/cursors.py#L237
to string format an empty list, erroring with:

```py
File "/usr/local/lib/python3.6/site-packages/aiomysql/utils.py", line 75, in __await__
    resp = yield from self._coro
  File "/usr/local/lib/python3.6/site-packages/aiomysql/sa/connection.py", line 77, in _execute
    yield from cursor.execute(query, dp)
  File "/usr/local/lib/python3.6/site-packages/aiomysql/cursors.py", line 238, in execute
    query = query % self._escape_args(args, conn)
TypeError: not enough arguments for format string
```