### PR TITLE
Add fetching row iteration by for cycle to Cursor

### DIFF
--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -485,6 +485,9 @@ class Cursor:
             msg = w[-1]
             warnings.warn(str(msg), Warning, 4)
 
+    def __iter__(self):
+        yield from self.fetchone()
+
     Warning = Warning
     Error = Error
     InterfaceError = InterfaceError

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -304,3 +304,14 @@ class TestCursor(base.AIOPyMySQLTestCase):
 
         with self.assertRaises(InterfaceError):
             yield from conn.cursor()
+
+    @run_until_complete
+    def test_fetchone_stepping_by_for_cycle(self):
+        """Tests fetching iteration by `for` cycle"""
+        expected_rows = [(1, 'a'), (2, 'b'), (3, 'c')]
+        conn = self.connections[0]
+        yield from self._prepare(conn)
+        cur = yield from conn.cursor()
+        yield from cur.execute('SELECT * FROM tbl;')
+        for actual_row, expected_row in zip(cur, expected_rows):
+            self.assertEqual(actual_row, expected_row)


### PR DESCRIPTION
```
async with connection.cursor() as cursor:
    await cursor.execute(query)
    for row in cursor:
        print(row)
```

The same functionality is allowed in PyMysql.