### PR TITLE
commit in the examples

### DIFF
--- a/docs/sa.rst
+++ b/docs/sa.rst
@@ -49,6 +49,8 @@ Example::
             for row in res:
                 print(row.id, row.val)
 
+            await conn.commit()
+
     asyncio.get_event_loop().run_until_complete(go())
 
 

--- a/examples/example_simple_sa.py
+++ b/examples/example_simple_sa.py
@@ -30,6 +30,8 @@ async def go(loop):
         async for row in conn.execute(tbl.select()):
             print(row.id, row.val)
 
+        await conn.commit()
+
     engine.close()
     await engine.wait_closed()
 

--- a/examples/example_simple_sa_oldstyle.py
+++ b/examples/example_simple_sa_oldstyle.py
@@ -35,6 +35,8 @@ def go():
         for row in res:
             print(row.id, row.val)
 
+        yield from conn.commit()
+
     engine.close()
     yield from engine.wait_closed()
 


### PR DESCRIPTION
I think I did the old-style correctly.

At first I was doing `conn.execute('commit')`, but then I realized the connection object has a commit method that does a bit more so I switched to using that.

Let me know if I missed anything.