### PR TITLE
Replace yield from with await...

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -432,7 +432,7 @@ class Connection:
         # Make sure charset is supported.
         encoding = charset_by_name(charset).encoding
         await self._execute_command(COMMAND.COM_QUERY, "SET NAMES %s"
-                                         % self.escape(charset))
+                                    % self.escape(charset))
         await self._read_packet()
         self._charset = charset
         self._encoding = encoding

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -41,12 +41,11 @@ from pymysql.connections import lenenc_int
 
 # from aiomysql.utils import _convert_to_str
 from .cursors import Cursor
-from .utils import (PY_35, _ConnectionContextManager, _ContextManager,
+from .utils import (_ConnectionContextManager, _ContextManager,
                     create_future)
 # from .log import logger
 
 DEFAULT_USER = getpass.getuser()
-PY_341 = sys.version_info >= (3, 4, 1)
 
 
 def connect(host="localhost", user=None, password="",
@@ -73,10 +72,9 @@ def connect(host="localhost", user=None, password="",
     return _ConnectionContextManager(coro)
 
 
-@asyncio.coroutine
-def _connect(*args, **kwargs):
+async def _connect(*args, **kwargs):
     conn = Connection(*args, **kwargs)
-    yield from conn._connect()
+    await conn._connect()
     return conn
 
 
@@ -280,19 +278,17 @@ class Connection:
         self._writer = None
         self._reader = None
 
-    @asyncio.coroutine
-    def ensure_closed(self):
+    async def ensure_closed(self):
         """Send quit command and then close socket connection"""
         if self._writer is None:
             # connection has been closed
             return
         send_data = struct.pack('<i', 1) + int2byte(COMMAND.COM_QUIT)
         self._writer.write(send_data)
-        yield from self._writer.drain()
+        await self._writer.drain()
         self.close()
 
-    @asyncio.coroutine
-    def autocommit(self, value):
+    async def autocommit(self, value):
         """Enable/disable autocommit mode for current MySQL session.
 
         :param value: ``bool``, toggle autocommit
@@ -300,7 +296,7 @@ class Connection:
         self.autocommit_mode = bool(value)
         current = self.get_autocommit()
         if value != current:
-            yield from self._send_autocommit_mode()
+            await self._send_autocommit_mode()
 
     def get_autocommit(self):
         """Returns autocommit status for current MySQL session.
@@ -310,53 +306,46 @@ class Connection:
         status = self.server_status & SERVER_STATUS.SERVER_STATUS_AUTOCOMMIT
         return bool(status)
 
-    @asyncio.coroutine
-    def _read_ok_packet(self):
-        pkt = yield from self._read_packet()
+    async def _read_ok_packet(self):
+        pkt = await self._read_packet()
         if not pkt.is_ok_packet():
             raise OperationalError(2014, "Command Out of Sync")
         ok = OKPacketWrapper(pkt)
         self.server_status = ok.server_status
         return True
 
-    @asyncio.coroutine
-    def _send_autocommit_mode(self):
+    async def _send_autocommit_mode(self):
         """Set whether or not to commit after every execute() """
-        yield from self._execute_command(
+        await self._execute_command(
             COMMAND.COM_QUERY,
             "SET AUTOCOMMIT = %s" % self.escape(self.autocommit_mode))
-        yield from self._read_ok_packet()
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def begin(self):
+    async def begin(self):
         """Begin transaction."""
-        yield from self._execute_command(COMMAND.COM_QUERY, "BEGIN")
-        yield from self._read_ok_packet()
+        await self._execute_command(COMMAND.COM_QUERY, "BEGIN")
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def commit(self):
+    async def commit(self):
         """Commit changes to stable storage."""
-        yield from self._execute_command(COMMAND.COM_QUERY, "COMMIT")
-        yield from self._read_ok_packet()
+        await self._execute_command(COMMAND.COM_QUERY, "COMMIT")
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def rollback(self):
+    async def rollback(self):
         """Roll back the current transaction."""
-        yield from self._execute_command(COMMAND.COM_QUERY, "ROLLBACK")
-        yield from self._read_ok_packet()
+        await self._execute_command(COMMAND.COM_QUERY, "ROLLBACK")
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def select_db(self, db):
+    async def select_db(self, db):
         """Set current db"""
-        yield from self._execute_command(COMMAND.COM_INIT_DB, db)
-        yield from self._read_ok_packet()
+        await self._execute_command(COMMAND.COM_INIT_DB, db)
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def show_warnings(self):
+    async def show_warnings(self):
         """SHOW WARNINGS"""
-        yield from self._execute_command(COMMAND.COM_QUERY, "SHOW WARNINGS")
+        await self._execute_command(COMMAND.COM_QUERY, "SHOW WARNINGS")
         result = MySQLResult(self)
-        yield from result.read()
+        await result.read()
         return result.rows
 
     def escape(self, obj):
@@ -400,73 +389,67 @@ class Connection:
         return _ContextManager(fut)
 
     # The following methods are INTERNAL USE ONLY (called from Cursor)
-    @asyncio.coroutine
-    def query(self, sql, unbuffered=False):
+    async def query(self, sql, unbuffered=False):
         # logger.debug("DEBUG: sending query: %s", _convert_to_str(sql))
         if isinstance(sql, str):
             sql = sql.encode(self.encoding, 'surrogateescape')
-        yield from self._execute_command(COMMAND.COM_QUERY, sql)
-        yield from self._read_query_result(unbuffered=unbuffered)
+        await self._execute_command(COMMAND.COM_QUERY, sql)
+        await self._read_query_result(unbuffered=unbuffered)
         return self._affected_rows
 
-    @asyncio.coroutine
-    def next_result(self):
-        yield from self._read_query_result()
+    async def next_result(self):
+        await self._read_query_result()
         return self._affected_rows
 
     def affected_rows(self):
         return self._affected_rows
 
-    @asyncio.coroutine
-    def kill(self, thread_id):
+    async def kill(self, thread_id):
         arg = struct.pack('<I', thread_id)
-        yield from self._execute_command(COMMAND.COM_PROCESS_KILL, arg)
-        yield from self._read_ok_packet()
+        await self._execute_command(COMMAND.COM_PROCESS_KILL, arg)
+        await self._read_ok_packet()
 
-    @asyncio.coroutine
-    def ping(self, reconnect=True):
+    async def ping(self, reconnect=True):
         """Check if the server is alive"""
         if self._writer is None and self._reader is None:
             if reconnect:
-                yield from self._connect()
+                await self._connect()
                 reconnect = False
             else:
                 raise Error("Already closed")
         try:
-            yield from self._execute_command(COMMAND.COM_PING, "")
-            yield from self._read_ok_packet()
+            await self._execute_command(COMMAND.COM_PING, "")
+            await self._read_ok_packet()
         except Exception:
             if reconnect:
-                yield from self._connect()
-                yield from self.ping(False)
+                await self._connect()
+                await self.ping(False)
             else:
                 raise
 
-    @asyncio.coroutine
-    def set_charset(self, charset):
+    async def set_charset(self, charset):
         """Sets the character set for the current connection"""
         # Make sure charset is supported.
         encoding = charset_by_name(charset).encoding
-        yield from self._execute_command(COMMAND.COM_QUERY, "SET NAMES %s"
+        await self._execute_command(COMMAND.COM_QUERY, "SET NAMES %s"
                                          % self.escape(charset))
-        yield from self._read_packet()
+        await self._read_packet()
         self._charset = charset
         self._encoding = encoding
 
-    @asyncio.coroutine
-    def _connect(self):
+    async def _connect(self):
         # TODO: Set close callback
         # raise OperationalError(2006,
         # "MySQL server has gone away (%r)" % (e,))
         try:
             if self._unix_socket and self._host in ('localhost', '127.0.0.1'):
-                self._reader, self._writer = yield from \
+                self._reader, self._writer = await \
                     asyncio.open_unix_connection(self._unix_socket,
                                                  loop=self._loop)
                 self.host_info = "Localhost via UNIX socket: " + \
                                  self._unix_socket
             else:
-                self._reader, self._writer = yield from \
+                self._reader, self._writer = await \
                     asyncio.open_connection(self._host, self._port,
                                             loop=self._loop)
                 self._set_keep_alive()
@@ -478,20 +461,20 @@ class Connection:
 
             self._next_seq_id = 0
 
-            yield from self._get_server_information()
-            yield from self._request_authentication()
+            await self._get_server_information()
+            await self._request_authentication()
 
             self.connected_time = self._loop.time()
 
             if self.sql_mode is not None:
-                yield from self.query("SET sql_mode=%s" % (self.sql_mode,))
+                await self.query("SET sql_mode=%s" % (self.sql_mode,))
 
             if self.init_command is not None:
-                yield from self.query(self.init_command)
-                yield from self.commit()
+                await self.query(self.init_command)
+                await self.commit()
 
             if self.autocommit_mode is not None:
-                yield from self.autocommit(self.autocommit_mode)
+                await self.autocommit(self.autocommit_mode)
         except Exception as e:
             if self._writer:
                 self._writer.transport.close()
@@ -530,15 +513,14 @@ class Connection:
         self._write_bytes(data)
         self._next_seq_id = (self._next_seq_id + 1) % 256
 
-    @asyncio.coroutine
-    def _read_packet(self, packet_type=MysqlPacket):
+    async def _read_packet(self, packet_type=MysqlPacket):
         """Read an entire "mysql packet" in its entirety from the network
         and return a MysqlPacket type that represents the results.
         """
         buff = b''
         while True:
             try:
-                packet_header = yield from self._read_bytes(4)
+                packet_header = await self._read_bytes(4)
             except asyncio.CancelledError:
                 self._close_on_cancel()
                 raise
@@ -557,7 +539,7 @@ class Connection:
             self._next_seq_id = (self._next_seq_id + 1) % 256
 
             try:
-                recv_data = yield from self._read_bytes(bytes_to_read)
+                recv_data = await self._read_bytes(bytes_to_read)
             except asyncio.CancelledError:
                 self._close_on_cancel()
                 raise
@@ -573,10 +555,9 @@ class Connection:
         packet.check_error()
         return packet
 
-    @asyncio.coroutine
-    def _read_bytes(self, num_bytes):
+    async def _read_bytes(self, num_bytes):
         try:
-            data = yield from self._reader.readexactly(num_bytes)
+            data = await self._reader.readexactly(num_bytes)
         except asyncio.streams.IncompleteReadError as e:
             msg = "Lost connection to MySQL server during query"
             raise OperationalError(2013, msg) from e
@@ -588,19 +569,18 @@ class Connection:
     def _write_bytes(self, data):
         return self._writer.write(data)
 
-    @asyncio.coroutine
-    def _read_query_result(self, unbuffered=False):
+    async def _read_query_result(self, unbuffered=False):
         if unbuffered:
             try:
                 result = MySQLResult(self)
-                yield from result.init_unbuffered_query()
+                await result.init_unbuffered_query()
             except BaseException:
                 result.unbuffered_active = False
                 result.connection = None
                 raise
         else:
             result = MySQLResult(self)
-            yield from result.read()
+            await result.read()
         self._result = result
         self._affected_rows = result.affected_rows
         if result.server_status is not None:
@@ -612,21 +592,17 @@ class Connection:
         else:
             return 0
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aenter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc_val, exc_tb):
-            if exc_type:
-                self.close()
-            else:
-                yield from self.ensure_closed()
-            return
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            self.close()
+        else:
+            await self.ensure_closed()
+        return
 
-    @asyncio.coroutine
-    def _execute_command(self, command, sql):
+    async def _execute_command(self, command, sql):
         self._ensure_alive()
 
         # If the last query was unbuffered, make sure it finishes before
@@ -636,7 +612,7 @@ class Connection:
                 warnings.warn("Previous unbuffered result was left incomplete")
                 self._result._finish_unbuffered_query()
             while self._result.has_next:
-                yield from self.next_result()
+                await self.next_result()
             self._result = None
 
         if isinstance(sql, str):
@@ -660,8 +636,7 @@ class Connection:
             if not sql and chunk_size < MAX_PACKET_LEN:
                 break
 
-    @asyncio.coroutine
-    def _request_authentication(self):
+    async def _request_authentication(self):
         # https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
         if int(self.server_version.split('.', 1)[0]) >= 5:
             self.client_flag |= CLIENT.MULTI_RESULTS
@@ -691,7 +666,7 @@ class Connection:
             # TCP connection not at start. Passing in a socket to
             # open_connection will cause it to negotiate TLS on an existing
             # connection not initiate a new one.
-            self._reader, self._writer = yield from asyncio.open_connection(
+            self._reader, self._writer = await asyncio.open_connection(
                 sock=raw_sock, ssl=self._ssl_context, loop=self._loop,
                 server_hostname=self._host
             )
@@ -742,7 +717,7 @@ class Connection:
         self._auth_plugin_used = auth_plugin
 
         self.write_packet(data)
-        auth_packet = yield from self._read_packet()
+        auth_packet = await self._read_packet()
 
         # if authentication method isn't accepted the first byte
         # will have the octet 254
@@ -753,17 +728,16 @@ class Connection:
             plugin_name = auth_packet.read_string()
             if (self.server_capabilities & CLIENT.PLUGIN_AUTH and
                     plugin_name is not None):
-                auth_packet = yield from self._process_auth(
+                auth_packet = await self._process_auth(
                     plugin_name, auth_packet)
             else:
                 # send legacy handshake
                 data = _scramble_323(self._password.encode('latin1'),
                                      self.salt) + b'\0'
                 self.write_packet(data)
-                auth_packet = yield from self._read_packet()
+                auth_packet = await self._read_packet()
 
-    @asyncio.coroutine
-    def _process_auth(self, plugin_name, auth_packet):
+    async def _process_auth(self, plugin_name, auth_packet):
         if plugin_name == b"mysql_native_password":
             # https://dev.mysql.com/doc/internals/en/
             # secure-password-authentication.html#packet-Authentication::
@@ -785,7 +759,7 @@ class Connection:
             )
 
         self.write_packet(data)
-        pkt = yield from self._read_packet()
+        pkt = await self._read_packet()
         pkt.check_error()
 
         self._auth_plugin_used = plugin_name
@@ -805,10 +779,9 @@ class Connection:
     def get_proto_info(self):
         return self.protocol_version
 
-    @asyncio.coroutine
-    def _get_server_information(self):
+    async def _get_server_information(self):
         i = 0
-        packet = yield from self._read_packet()
+        packet = await self._read_packet()
         data = packet.get_all_data()
         # logger.debug(dump_packet(data))
         self.protocol_version = byte2int(data[i:i + 1])
@@ -883,12 +856,11 @@ class Connection:
             else:
                 raise InterfaceError(self._close_reason)
 
-    if PY_341:  # pragma: no branch
-        def __del__(self):
-            if self._writer:
-                warnings.warn("Unclosed connection {!r}".format(self),
-                              ResourceWarning)
-                self.close()
+    def __del__(self):
+        if self._writer:
+            warnings.warn("Unclosed connection {!r}".format(self),
+                          ResourceWarning)
+            self.close()
     Warning = Warning
     Error = Error
     InterfaceError = InterfaceError
@@ -918,37 +890,35 @@ class MySQLResult:
         self.has_next = None
         self.unbuffered_active = False
 
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         try:
-            first_packet = yield from self.connection._read_packet()
+            first_packet = await self.connection._read_packet()
 
             # TODO: use classes for different packet types?
             if first_packet.is_ok_packet():
                 self._read_ok_packet(first_packet)
             elif first_packet.is_load_local_packet():
-                yield from self._read_load_local_packet(first_packet)
+                await self._read_load_local_packet(first_packet)
             else:
-                yield from self._read_result_packet(first_packet)
+                await self._read_result_packet(first_packet)
         finally:
             self.connection = None
 
-    @asyncio.coroutine
-    def init_unbuffered_query(self):
+    async def init_unbuffered_query(self):
         self.unbuffered_active = True
-        first_packet = yield from self.connection._read_packet()
+        first_packet = await self.connection._read_packet()
 
         if first_packet.is_ok_packet():
             self._read_ok_packet(first_packet)
             self.unbuffered_active = False
             self.connection = None
         elif first_packet.is_load_local_packet():
-            yield from self._read_load_local_packet(first_packet)
+            await self._read_load_local_packet(first_packet)
             self.unbuffered_active = False
             self.connection = None
         else:
             self.field_count = first_packet.read_length_encoded_integer()
-            yield from self._get_descriptions()
+            await self._get_descriptions()
 
             # Apparently, MySQLdb picks this number because it's the maximum
             # value of a 64bit unsigned integer. Since we're emulating MySQLdb,
@@ -964,18 +934,17 @@ class MySQLResult:
         self.message = ok_packet.message
         self.has_next = ok_packet.has_next
 
-    @asyncio.coroutine
-    def _read_load_local_packet(self, first_packet):
+    async def _read_load_local_packet(self, first_packet):
         load_packet = LoadLocalPacketWrapper(first_packet)
         sender = LoadLocalFile(load_packet.filename, self.connection)
         try:
-            yield from sender.send_data()
+            await sender.send_data()
         except Exception:
             # Skip ok packet
-            yield from self.connection._read_packet()
+            await self.connection._read_packet()
             raise
 
-        ok_packet = yield from self.connection._read_packet()
+        ok_packet = await self.connection._read_packet()
         if not ok_packet.is_ok_packet():
             raise OperationalError(2014, "Commands Out of Sync")
         self._read_ok_packet(ok_packet)
@@ -988,19 +957,17 @@ class MySQLResult:
             return True
         return False
 
-    @asyncio.coroutine
-    def _read_result_packet(self, first_packet):
+    async def _read_result_packet(self, first_packet):
         self.field_count = first_packet.read_length_encoded_integer()
-        yield from self._get_descriptions()
-        yield from self._read_rowdata_packet()
+        await self._get_descriptions()
+        await self._read_rowdata_packet()
 
-    @asyncio.coroutine
-    def _read_rowdata_packet_unbuffered(self):
+    async def _read_rowdata_packet_unbuffered(self):
         # Check if in an active query
         if not self.unbuffered_active:
             return
 
-        packet = yield from self.connection._read_packet()
+        packet = await self.connection._read_packet()
         if self._check_packet_is_eof(packet):
             self.unbuffered_active = False
             self.connection = None
@@ -1013,24 +980,22 @@ class MySQLResult:
         self.rows = (row,)
         return row
 
-    @asyncio.coroutine
-    def _finish_unbuffered_query(self):
+    async def _finish_unbuffered_query(self):
         # After much reading on the MySQL protocol, it appears that there is,
         # in fact, no way to stop MySQL from sending all the data after
         # executing a query, so we just spin, and wait for an EOF packet.
         while self.unbuffered_active:
-            packet = yield from self.connection._read_packet()
+            packet = await self.connection._read_packet()
             if self._check_packet_is_eof(packet):
                 self.unbuffered_active = False
                 # release reference to kill cyclic reference.
                 self.connection = None
 
-    @asyncio.coroutine
-    def _read_rowdata_packet(self):
+    async def _read_rowdata_packet(self):
         """Read a rowdata packet for each data row in the result set."""
         rows = []
         while True:
-            packet = yield from self.connection._read_packet()
+            packet = await self.connection._read_packet()
             if self._check_packet_is_eof(packet):
                 # release reference to kill cyclic reference.
                 self.connection = None
@@ -1057,8 +1022,7 @@ class MySQLResult:
             row.append(data)
         return tuple(row)
 
-    @asyncio.coroutine
-    def _get_descriptions(self):
+    async def _get_descriptions(self):
         """Read a column descriptor packet for each column in the result."""
         self.fields = []
         self.converters = []
@@ -1066,7 +1030,7 @@ class MySQLResult:
         conn_encoding = self.connection.encoding
         description = []
         for i in range(self.field_count):
-            field = yield from self.connection._read_packet(
+            field = await self.connection._read_packet(
                 FieldDescriptorPacket)
             self.fields.append(field)
             description.append(field.description())
@@ -1098,7 +1062,7 @@ class MySQLResult:
                 converter = None
             self.converters.append((encoding, converter))
 
-        eof_packet = yield from self.connection._read_packet()
+        eof_packet = await self.connection._read_packet()
         assert eof_packet.is_eof_packet(), 'Protocol error, expecting EOF'
         self.description = tuple(description)
 
@@ -1143,18 +1107,17 @@ class LoadLocalFile(object):
         fut = self._loop.run_in_executor(self._executor, freader, chunk_size)
         return fut
 
-    @asyncio.coroutine
-    def send_data(self):
+    async def send_data(self):
         """Send data packets from the local file to the server"""
         self.connection._ensure_alive()
         conn = self.connection
 
         try:
-            yield from self._open_file()
+            await self._open_file()
             with self._file_object:
                 chunk_size = MAX_PACKET_LEN
                 while True:
-                    chunk = yield from self._file_read(chunk_size)
+                    chunk = await self._file_read(chunk_size)
                     if not chunk:
                         break
                     # TODO: consider drain data

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 import warnings
 
@@ -287,8 +286,8 @@ class Cursor:
             self._rowcount = rows
         return self._rowcount
 
-    async def _do_execute_many(self, prefix, values, postfix, args, max_stmt_length,
-                         encoding):
+    async def _do_execute_many(self, prefix, values, postfix, args,
+                               max_stmt_length, encoding):
         conn = self._get_db()
         escape = self._escape_args
         if isinstance(prefix, str):

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -8,7 +8,7 @@ from pymysql.err import (
     NotSupportedError, ProgrammingError)
 
 from .log import logger
-from .utils import PY_35, create_future
+from .utils import create_future
 
 
 # https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/cursors.py#L11-L18
@@ -149,14 +149,13 @@ class Cursor:
         """
         return True if not self._connection else False
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         """Closing a cursor just exhausts all remaining data."""
         conn = self._connection
         if conn is None:
             return
         try:
-            while (yield from self.nextset()):
+            while (await self.nextset()):
                 pass
         finally:
             self._connection = None
@@ -179,8 +178,7 @@ class Cursor:
     def setoutputsizes(self, *args):
         """Does nothing, required by DB API."""
 
-    @asyncio.coroutine
-    def nextset(self):
+    async def nextset(self):
         """Get the next query set"""
         conn = self._get_db()
         current_result = self._result
@@ -188,8 +186,8 @@ class Cursor:
             return
         if not current_result.has_next:
             return
-        yield from conn.next_result()
-        yield from self._do_get_result()
+        await conn.next_result()
+        await self._do_get_result()
         return True
 
     def _escape_args(self, args, conn):
@@ -215,8 +213,7 @@ class Cursor:
             query = query % self._escape_args(args, conn)
         return query
 
-    @asyncio.coroutine
-    def execute(self, query, args=None):
+    async def execute(self, query, args=None):
         """Executes the given operation
 
         Executes the given operation substituting any markers with
@@ -231,21 +228,20 @@ class Cursor:
         """
         conn = self._get_db()
 
-        while (yield from self.nextset()):
+        while (await self.nextset()):
             pass
 
         if args is not None:
             query = query % self._escape_args(args, conn)
 
-        yield from self._query(query)
+        await self._query(query)
         self._executed = query
         if self._echo:
             logger.info(query)
             logger.info("%r", args)
         return self._rowcount
 
-    @asyncio.coroutine
-    def executemany(self, query, args):
+    async def executemany(self, query, args):
         """Execute the given operation multiple times
 
         The executemany() method will execute the operation iterating
@@ -259,7 +255,7 @@ class Cursor:
                 ('John', '555-003')
                 ]
             stmt = "INSERT INTO employees (name, phone) VALUES ('%s','%s')"
-            yield from cursor.executemany(stmt, data)
+            await cursor.executemany(stmt, data)
 
         INSERT or REPLACE statements are optimized by batching the data,
         that is using the MySQL multiple rows syntax.
@@ -280,19 +276,18 @@ class Cursor:
             q_values = m.group(2).rstrip()
             q_postfix = m.group(3) or ''
             assert q_values[0] == '(' and q_values[-1] == ')'
-            return (yield from self._do_execute_many(
+            return (await self._do_execute_many(
                 q_prefix, q_values, q_postfix, args, self.max_stmt_length,
                 self._get_db().encoding))
         else:
             rows = 0
             for arg in args:
-                yield from self.execute(query, arg)
+                await self.execute(query, arg)
                 rows += self._rowcount
             self._rowcount = rows
         return self._rowcount
 
-    @asyncio.coroutine
-    def _do_execute_many(self, prefix, values, postfix, args, max_stmt_length,
+    async def _do_execute_many(self, prefix, values, postfix, args, max_stmt_length,
                          encoding):
         conn = self._get_db()
         escape = self._escape_args
@@ -312,19 +307,18 @@ class Cursor:
             if isinstance(v, str):
                 v = v.encode(encoding, 'surrogateescape')
             if len(sql) + len(v) + len(postfix) + 1 > max_stmt_length:
-                r = yield from self.execute(sql + postfix)
+                r = await self.execute(sql + postfix)
                 rows += r
                 sql = bytearray(prefix)
             else:
                 sql += b','
             sql += v
-        r = yield from self.execute(sql + postfix)
+        r = await self.execute(sql + postfix)
         rows += r
         self._rowcount = rows
         return rows
 
-    @asyncio.coroutine
-    def callproc(self, procname, args=()):
+    async def callproc(self, procname, args=()):
         """Execute stored procedure procname with args
 
         Compatibility warning: PEP-249 specifies that any modified
@@ -357,12 +351,12 @@ class Cursor:
 
         for index, arg in enumerate(args):
             q = "SET @_%s_%d=%s" % (procname, index, conn.escape(arg))
-            yield from self._query(q)
-            yield from self.nextset()
+            await self._query(q)
+            await self.nextset()
 
         _args = ','.join('@_%s_%d' % (procname, i) for i in range(len(args)))
         q = "CALL %s(%s)" % (procname, _args)
-        yield from self._query(q)
+        await self._query(q)
         self._executed = q
         return args
 
@@ -454,15 +448,13 @@ class Cursor:
         fut.set_result(None)
         return fut
 
-    @asyncio.coroutine
-    def _query(self, q):
+    async def _query(self, q):
         conn = self._get_db()
         self._last_executed = q
-        yield from conn.query(q)
-        yield from self._do_get_result()
+        await conn.query(q)
+        await self._do_get_result()
 
-    @asyncio.coroutine
-    def _do_get_result(self):
+    async def _do_get_result(self):
         conn = self._get_db()
         self._rownumber = 0
         self._result = result = conn._result
@@ -472,13 +464,12 @@ class Cursor:
         self._rows = result.rows
 
         if result.warning_count > 0:
-            yield from self._show_warnings(conn)
+            await self._show_warnings(conn)
 
-    @asyncio.coroutine
-    def _show_warnings(self, conn):
+    async def _show_warnings(self, conn):
         if self._result and self._result.has_next:
             return
-        ws = yield from conn.show_warnings()
+        ws = await conn.show_warnings()
         if ws is None:
             return
         for w in ws:
@@ -496,36 +487,30 @@ class Cursor:
     ProgrammingError = ProgrammingError
     NotSupportedError = NotSupportedError
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+    async def __aiter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __anext__(self):
-            ret = yield from self.fetchone()
-            if ret is not None:
-                return ret
-            else:
-                raise StopAsyncIteration  # noqa
+    async def __anext__(self):
+        ret = await self.fetchone()
+        if ret is not None:
+            return ret
+        else:
+            raise StopAsyncIteration  # noqa
 
-        @asyncio.coroutine
-        def __aenter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc_val, exc_tb):
-            yield from self.close()
-            return
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+        return
 
 
 class _DictCursorMixin:
     # You can override this to use OrderedDict or other dict-like types.
     dict_type = dict
 
-    @asyncio.coroutine
-    def _do_get_result(self):
-        yield from super()._do_get_result()
+    async def _do_get_result(self):
+        await super()._do_get_result()
         fields = []
         if self._description:
             for f in self._result.fields:
@@ -563,61 +548,55 @@ class SSCursor(Cursor):
     possible to scroll backwards, as only the current row is held in memory.
     """
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         conn = self._connection
         if conn is None:
             return
 
         if self._result is not None and self._result is conn._result:
-            yield from self._result._finish_unbuffered_query()
+            await self._result._finish_unbuffered_query()
 
         try:
-            while (yield from self.nextset()):
+            while (await self.nextset()):
                 pass
         finally:
             self._connection = None
 
-    @asyncio.coroutine
-    def _query(self, q):
+    async def _query(self, q):
         conn = self._get_db()
         self._last_executed = q
-        yield from conn.query(q, unbuffered=True)
-        yield from self._do_get_result()
+        await conn.query(q, unbuffered=True)
+        await self._do_get_result()
         return self._rowcount
 
-    @asyncio.coroutine
-    def _read_next(self):
+    async def _read_next(self):
         """Read next row """
-        row = yield from self._result._read_rowdata_packet_unbuffered()
+        row = await self._result._read_rowdata_packet_unbuffered()
         row = self._conv_row(row)
         return row
 
-    @asyncio.coroutine
-    def fetchone(self):
+    async def fetchone(self):
         """ Fetch next row """
         self._check_executed()
-        row = yield from self._read_next()
+        row = await self._read_next()
         if row is None:
             return
         self._rownumber += 1
         return row
 
-    @asyncio.coroutine
-    def fetchall(self):
+    async def fetchall(self):
         """Fetch all, as per MySQLdb. Pretty useless for large queries, as
         it is buffered.
         """
         rows = []
         while True:
-            row = yield from self.fetchone()
+            row = await self.fetchone()
             if row is None:
                 break
             rows.append(row)
         return rows
 
-    @asyncio.coroutine
-    def fetchmany(self, size=None):
+    async def fetchmany(self, size=None):
         """Returns the next set of rows of a query result, returning a
         list of tuples. When no more rows are available, it returns an
         empty list.
@@ -634,15 +613,14 @@ class SSCursor(Cursor):
 
         rows = []
         for i in range(size):
-            row = yield from self._read_next()
+            row = await self._read_next()
             if row is None:
                 break
             rows.append(row)
             self._rownumber += 1
         return rows
 
-    @asyncio.coroutine
-    def scroll(self, value, mode='relative'):
+    async def scroll(self, value, mode='relative'):
         """Scroll the cursor in the result set to a new position
         according to mode . Same as :meth:`Cursor.scroll`, but move cursor
         on server side one by one row. If you want to move 20 rows forward
@@ -661,7 +639,7 @@ class SSCursor(Cursor):
                                         "by this cursor")
 
             for _ in range(value):
-                yield from self._read_next()
+                await self._read_next()
             self._rownumber += value
         elif mode == 'absolute':
             if value < self._rownumber:
@@ -670,7 +648,7 @@ class SSCursor(Cursor):
 
             end = value - self._rownumber
             for _ in range(end):
-                yield from self._read_next()
+                await self._read_next()
             self._rownumber = value
         else:
             raise ProgrammingError("unknown scroll mode %s" % mode)

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -18,7 +18,7 @@ def create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
 
 
 async def _create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
-                 loop=None, **kwargs):
+                       loop=None, **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
 
@@ -165,7 +165,7 @@ class Pool(asyncio.AbstractServer):
             self._acquiring += 1
             try:
                 conn = await connect(echo=self._echo, loop=self._loop,
-                                          **self._conn_kwargs)
+                                     **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
@@ -178,7 +178,7 @@ class Pool(asyncio.AbstractServer):
             self._acquiring += 1
             try:
                 conn = await connect(echo=self._echo, loop=self._loop,
-                                          **self._conn_kwargs)
+                                     **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -6,7 +6,7 @@ import collections
 import warnings
 
 from .connection import connect
-from .utils import (PY_35, _PoolContextManager, _PoolConnectionContextManager,
+from .utils import (_PoolContextManager, _PoolConnectionContextManager,
                     _PoolAcquireContextManager, create_future, create_task)
 
 
@@ -17,8 +17,7 @@ def create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
     return _PoolContextManager(coro)
 
 
-@asyncio.coroutine
-def _create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
+async def _create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
                  loop=None, **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -26,8 +25,8 @@ def _create_pool(minsize=1, maxsize=10, echo=False, pool_recycle=-1,
     pool = Pool(minsize=minsize, maxsize=maxsize, echo=echo,
                 pool_recycle=pool_recycle, loop=loop, **kwargs)
     if minsize > 0:
-        with (yield from pool._cond):
-            yield from pool._fill_free_pool(False)
+        with (await pool._cond):
+            await pool._fill_free_pool(False)
     return pool
 
 
@@ -72,13 +71,12 @@ class Pool(asyncio.AbstractServer):
     def freesize(self):
         return len(self._free)
 
-    @asyncio.coroutine
-    def clear(self):
+    async def clear(self):
         """Close all free connections in pool."""
-        with (yield from self._cond):
+        with (await self._cond):
             while self._free:
                 conn = self._free.popleft()
-                yield from conn.ensure_closed()
+                await conn.ensure_closed()
             self._cond.notify()
 
     def close(self):
@@ -105,8 +103,7 @@ class Pool(asyncio.AbstractServer):
 
         self._used.clear()
 
-    @asyncio.coroutine
-    def wait_closed(self):
+    async def wait_closed(self):
         """Wait for closing all pool's connections."""
 
         if self._closed:
@@ -119,9 +116,9 @@ class Pool(asyncio.AbstractServer):
             conn = self._free.popleft()
             conn.close()
 
-        with (yield from self._cond):
+        with (await self._cond):
             while self.size > self.freesize:
-                yield from self._cond.wait()
+                await self._cond.wait()
 
         self._closed = True
 
@@ -130,13 +127,12 @@ class Pool(asyncio.AbstractServer):
         coro = self._acquire()
         return _PoolAcquireContextManager(coro, self)
 
-    @asyncio.coroutine
-    def _acquire(self):
+    async def _acquire(self):
         if self._closing:
             raise RuntimeError("Cannot acquire connection after closing pool")
-        with (yield from self._cond):
+        with (await self._cond):
             while True:
-                yield from self._fill_free_pool(True)
+                await self._fill_free_pool(True)
                 if self._free:
                     conn = self._free.popleft()
                     assert not conn.closed, conn
@@ -144,10 +140,9 @@ class Pool(asyncio.AbstractServer):
                     self._used.add(conn)
                     return conn
                 else:
-                    yield from self._cond.wait()
+                    await self._cond.wait()
 
-    @asyncio.coroutine
-    def _fill_free_pool(self, override_min):
+    async def _fill_free_pool(self, override_min):
         # iterate over free connections and remove timeouted ones
         free_size = len(self._free)
         n = 0
@@ -169,7 +164,7 @@ class Pool(asyncio.AbstractServer):
         while self.size < self.minsize:
             self._acquiring += 1
             try:
-                conn = yield from connect(echo=self._echo, loop=self._loop,
+                conn = await connect(echo=self._echo, loop=self._loop,
                                           **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
@@ -182,7 +177,7 @@ class Pool(asyncio.AbstractServer):
         if override_min and self.size < self.maxsize:
             self._acquiring += 1
             try:
-                conn = yield from connect(echo=self._echo, loop=self._loop,
+                conn = await connect(echo=self._echo, loop=self._loop,
                                           **self._conn_kwargs)
                 # raise exception if pool is closing
                 self._free.append(conn)
@@ -190,9 +185,8 @@ class Pool(asyncio.AbstractServer):
             finally:
                 self._acquiring -= 1
 
-    @asyncio.coroutine
-    def _wakeup(self):
-        with (yield from self._cond):
+    async def _wakeup(self):
+        with (await self._cond):
             self._cond.notify()
 
     def release(self, conn):
@@ -252,19 +246,16 @@ class Pool(asyncio.AbstractServer):
         conn = yield from self.acquire()
         return _PoolConnectionContextManager(self, conn)
 
-    if PY_35:  # pragma: no branch
-        def __await__(self):
-            msg = "with await pool as conn deprecated, use" \
-                  "async with pool.acquire() as conn instead"
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            conn = yield from self.acquire()
-            return _PoolConnectionContextManager(self, conn)
+    def __await__(self):
+        msg = "with await pool as conn deprecated, use" \
+              "async with pool.acquire() as conn instead"
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        conn = yield from self.acquire()
+        return _PoolConnectionContextManager(self, conn)
 
-        @asyncio.coroutine
-        def __aenter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc_val, exc_tb):
-            self.close()
-            yield from self.wait_closed()
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        await self.wait_closed()

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -1,6 +1,5 @@
 # ported from:
 # https://github.com/aio-libs/aiopg/blob/master/aiopg/sa/connection.py
-import asyncio
 import weakref
 
 from sqlalchemy.sql import ClauseElement

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -33,26 +33,26 @@ class SAConnection:
         used in the execution.  Typically, the format is a dictionary
         passed to *multiparams:
 
-            yield from conn.execute(
+            await conn.execute(
                 table.insert(),
                 {"id":1, "value":"v1"},
             )
 
         ...or individual key/values interpreted by **params::
 
-            yield from conn.execute(
+            await conn.execute(
                 table.insert(), id=1, value="v1"
             )
 
         In the case that a plain SQL string is passed, a tuple or
         individual values in \*multiparams may be passed::
 
-            yield from conn.execute(
+            await conn.execute(
                 "INSERT INTO table (id, value) VALUES (%d, %s)",
                 (1, "v1")
             )
 
-            yield from conn.execute(
+            await conn.execute(
                 "INSERT INTO table (id, value) VALUES (%s, %s)",
                 1, "v1"
             )
@@ -64,9 +64,8 @@ class SAConnection:
         coro = self._execute(query, *multiparams, **params)
         return _SAConnectionContextManager(coro)
 
-    @asyncio.coroutine
-    def _execute(self, query, *multiparams, **params):
-        cursor = yield from self._connection.cursor()
+    async def _execute(self, query, *multiparams, **params):
+        cursor = await self._connection.cursor()
         dp = _distill_params(multiparams, params)
         if len(dp) > 1:
             raise exc.ArgumentError("aiomysql doesn't support executemany")
@@ -74,7 +73,7 @@ class SAConnection:
             dp = dp[0]
 
         if isinstance(query, str):
-            yield from cursor.execute(query, dp or None)
+            await cursor.execute(query, dp or None)
         elif isinstance(query, ClauseElement):
             compiled = query.compile(dialect=self._dialect)
             # parameters = compiled.params
@@ -104,21 +103,20 @@ class SAConnection:
                     raise exc.ArgumentError("Don't mix sqlalchemy DDL clause "
                                             "and execution with parameters")
                 post_processed_params = [compiled.construct_params()]
-            yield from cursor.execute(str(compiled), post_processed_params[0])
+            await cursor.execute(str(compiled), post_processed_params[0])
         else:
             raise exc.ArgumentError("sql statement should be str or "
                                     "SQLAlchemy data "
                                     "selection/modification clause")
 
-        ret = yield from create_result_proxy(self, cursor, self._dialect)
+        ret = await create_result_proxy(self, cursor, self._dialect)
         self._weak_results.add(ret)
         return ret
 
-    @asyncio.coroutine
-    def scalar(self, query, *multiparams, **params):
+    async def scalar(self, query, *multiparams, **params):
         """Executes a SQL query and returns a scalar value."""
-        res = yield from self.execute(query, *multiparams, **params)
-        return (yield from res.scalar())
+        res = await self.execute(query, *multiparams, **params)
+        return (await res.scalar())
 
     @property
     def closed(self):
@@ -142,10 +140,10 @@ class SAConnection:
         transaction within the scope of the enclosing transaction,
         that is::
 
-            trans = yield from conn.begin()   # outermost transaction
-            trans2 = yield from conn.begin()  # "nested"
-            yield from trans2.commit()        # does nothing
-            yield from trans.commit()         # actually commits
+            trans = await conn.begin()   # outermost transaction
+            trans2 = await conn.begin()  # "nested"
+            await trans2.commit()        # does nothing
+            await trans.commit()         # actually commits
 
         Calls to .commit only have an effect when invoked via the
         outermost Transaction object, though the .rollback method of
@@ -159,43 +157,38 @@ class SAConnection:
         coro = self._begin()
         return _TransactionContextManager(coro)
 
-    @asyncio.coroutine
-    def _begin(self):
+    async def _begin(self):
         if self._transaction is None:
             self._transaction = RootTransaction(self)
-            yield from self._begin_impl()
+            await self._begin_impl()
             return self._transaction
         else:
             return Transaction(self, self._transaction)
 
-    @asyncio.coroutine
-    def _begin_impl(self):
-        cur = yield from self._connection.cursor()
+    async def _begin_impl(self):
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('BEGIN')
+            await cur.execute('BEGIN')
         finally:
-            yield from cur.close()
+            await cur.close()
 
-    @asyncio.coroutine
-    def _commit_impl(self):
-        cur = yield from self._connection.cursor()
+    async def _commit_impl(self):
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('COMMIT')
+            await cur.execute('COMMIT')
         finally:
-            yield from cur.close()
+            await cur.close()
             self._transaction = None
 
-    @asyncio.coroutine
-    def _rollback_impl(self):
-        cur = yield from self._connection.cursor()
+    async def _rollback_impl(self):
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('ROLLBACK')
+            await cur.execute('ROLLBACK')
         finally:
-            yield from cur.close()
+            await cur.close()
             self._transaction = None
 
-    @asyncio.coroutine
-    def begin_nested(self):
+    async def begin_nested(self):
         """Begin a nested transaction and return a transaction handle.
 
         The returned object is an instance of :class:`.NestedTransaction`.
@@ -208,44 +201,40 @@ class SAConnection:
         """
         if self._transaction is None:
             self._transaction = RootTransaction(self)
-            yield from self._begin_impl()
+            await self._begin_impl()
         else:
             self._transaction = NestedTransaction(self, self._transaction)
-            self._transaction._savepoint = yield from self._savepoint_impl()
+            self._transaction._savepoint = await self._savepoint_impl()
         return self._transaction
 
-    @asyncio.coroutine
-    def _savepoint_impl(self, name=None):
+    async def _savepoint_impl(self, name=None):
         self._savepoint_seq += 1
         name = 'aiomysql_sa_savepoint_%s' % self._savepoint_seq
 
-        cur = yield from self._connection.cursor()
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('SAVEPOINT ' + name)
+            await cur.execute('SAVEPOINT ' + name)
             return name
         finally:
-            yield from cur.close()
+            await cur.close()
 
-    @asyncio.coroutine
-    def _rollback_to_savepoint_impl(self, name, parent):
-        cur = yield from self._connection.cursor()
+    async def _rollback_to_savepoint_impl(self, name, parent):
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('ROLLBACK TO SAVEPOINT ' + name)
+            await cur.execute('ROLLBACK TO SAVEPOINT ' + name)
         finally:
-            yield from cur.close()
+            await cur.close()
         self._transaction = parent
 
-    @asyncio.coroutine
-    def _release_savepoint_impl(self, name, parent):
-        cur = yield from self._connection.cursor()
+    async def _release_savepoint_impl(self, name, parent):
+        cur = await self._connection.cursor()
         try:
-            yield from cur.execute('RELEASE SAVEPOINT ' + name)
+            await cur.execute('RELEASE SAVEPOINT ' + name)
         finally:
-            yield from cur.close()
+            await cur.close()
         self._transaction = parent
 
-    @asyncio.coroutine
-    def begin_twophase(self, xid=None):
+    async def begin_twophase(self, xid=None):
         """Begin a two-phase or XA transaction and return a transaction
         handle.
 
@@ -265,41 +254,36 @@ class SAConnection:
         if xid is None:
             xid = self._dialect.create_xid()
         self._transaction = TwoPhaseTransaction(self, xid)
-        yield from self.execute("XA START %s", xid)
+        await self.execute("XA START %s", xid)
         return self._transaction
 
-    @asyncio.coroutine
-    def _prepare_twophase_impl(self, xid):
-        yield from self.execute("XA END '%s'" % xid)
-        yield from self.execute("XA PREPARE '%s'" % xid)
+    async def _prepare_twophase_impl(self, xid):
+        await self.execute("XA END '%s'" % xid)
+        await self.execute("XA PREPARE '%s'" % xid)
 
-    @asyncio.coroutine
-    def recover_twophase(self):
+    async def recover_twophase(self):
         """Return a list of prepared twophase transaction ids."""
-        result = yield from self.execute("XA RECOVER;")
+        result = await self.execute("XA RECOVER;")
         return [row[0] for row in result]
 
-    @asyncio.coroutine
-    def rollback_prepared(self, xid, *, is_prepared=True):
+    async def rollback_prepared(self, xid, *, is_prepared=True):
         """Rollback prepared twophase transaction."""
         if not is_prepared:
-            yield from self.execute("XA END '%s'" % xid)
-        yield from self.execute("XA ROLLBACK '%s'" % xid)
+            await self.execute("XA END '%s'" % xid)
+        await self.execute("XA ROLLBACK '%s'" % xid)
 
-    @asyncio.coroutine
-    def commit_prepared(self, xid, *, is_prepared=True):
+    async def commit_prepared(self, xid, *, is_prepared=True):
         """Commit prepared twophase transaction."""
         if not is_prepared:
-            yield from self.execute("XA END '%s'" % xid)
-        yield from self.execute("XA COMMIT '%s'" % xid)
+            await self.execute("XA END '%s'" % xid)
+        await self.execute("XA COMMIT '%s'" % xid)
 
     @property
     def in_transaction(self):
         """Return True if a transaction is in progress."""
         return self._transaction is not None and self._transaction.is_active
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         """Close this SAConnection.
 
         This results in a release of the underlying database
@@ -317,7 +301,7 @@ class SAConnection:
             return
 
         if self._transaction is not None:
-            yield from self._transaction.rollback()
+            await self._transaction.rollback()
             self._transaction = None
         # don't close underlying connection, it can be reused by pool
         # conn.close()
@@ -325,13 +309,11 @@ class SAConnection:
         self._connection = None
         self._engine = None
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         return self
 
-    @asyncio.coroutine
-    def __aexit__(self, exc_type, exc_val, exc_tb):
-        yield from self.close()
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
 
 
 def _distill_params(multiparams, params):

--- a/aiomysql/sa/engine.py
+++ b/aiomysql/sa/engine.py
@@ -38,13 +38,13 @@ def create_engine(minsize=1, maxsize=10, loop=None,
 
 
 async def _create_engine(minsize=1, maxsize=10, loop=None,
-                   dialect=_dialect, pool_recycle=-1, **kwargs):
+                         dialect=_dialect, pool_recycle=-1, **kwargs):
 
     if loop is None:
         loop = asyncio.get_event_loop()
     pool = await aiomysql.create_pool(minsize=minsize, maxsize=maxsize,
-                                           loop=loop,
-                                           pool_recycle=pool_recycle, **kwargs)
+                                      loop=loop,
+                                      pool_recycle=pool_recycle, **kwargs)
     conn = await pool.acquire()
     try:
         return Engine(dialect, pool, **kwargs)

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -1,7 +1,6 @@
 # ported from:
 # https://github.com/aio-libs/aiopg/blob/master/aiopg/sa/result.py
 
-import asyncio
 import weakref
 from collections.abc import Mapping, Sequence
 

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -342,13 +342,13 @@ class ResultProxy:
             self._cursor = None
             self._weak = None
 
-    def __iter__(self):
-        while True:
-            row = yield from self.fetchone()
-            if row is None:
-                raise StopIteration
-            else:
-                yield row
+    # def __iter__(self):
+    #     while True:
+    #         row = yield from self.fetchone()
+    #         if row is None:
+    #             raise StopIteration
+    #         else:
+    #             yield row
 
     def _non_result(self):
         if self._metadata is None:

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -8,13 +8,12 @@ from collections.abc import Mapping, Sequence
 from sqlalchemy.sql import expression, sqltypes
 
 from . import exc
-from ..utils import PY_35, create_task
+from ..utils import create_task
 
 
-@asyncio.coroutine
-def create_result_proxy(connection, cursor, dialect):
+async def create_result_proxy(connection, cursor, dialect):
     result_proxy = ResultProxy(connection, cursor, dialect)
-    yield from result_proxy._prepare()
+    await result_proxy._prepare()
     return result_proxy
 
 
@@ -234,8 +233,7 @@ class ResultProxy:
         self._rowcount = cursor.rowcount
         self._lastrowid = cursor.lastrowid
 
-    @asyncio.coroutine
-    def _prepare(self):
+    async def _prepare(self):
         loop = self._connection.connection.loop
         cursor = self._cursor
         if cursor.description is not None:
@@ -246,7 +244,7 @@ class ResultProxy:
             self._weak = weakref.ref(self, callback)
         else:
             self._metadata = None
-            yield from self.close()
+            await self.close()
             self._weak = None
 
     @property
@@ -319,8 +317,7 @@ class ResultProxy:
     def closed(self):
         return self._closed
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         """Close this ResultProxy.
 
         Closes the underlying DBAPI cursor corresponding to the execution.
@@ -340,7 +337,7 @@ class ResultProxy:
 
         if not self._closed:
             self._closed = True
-            yield from self._cursor.close()
+            await self._cursor.close()
             # allow consistent errors
             self._cursor = None
             self._weak = None
@@ -369,38 +366,35 @@ class ResultProxy:
         return [process_row(metadata, row, processors, keymap)
                 for row in rows]
 
-    @asyncio.coroutine
-    def fetchall(self):
+    async def fetchall(self):
         """Fetch all rows, just like DB-API cursor.fetchall()."""
         try:
-            rows = yield from self._cursor.fetchall()
+            rows = await self._cursor.fetchall()
         except AttributeError:
             self._non_result()
         else:
             ret = self._process_rows(rows)
-            yield from self.close()
+            await self.close()
             return ret
 
-    @asyncio.coroutine
-    def fetchone(self):
+    async def fetchone(self):
         """Fetch one row, just like DB-API cursor.fetchone().
 
         If a row is present, the cursor remains open after this is called.
         Else the cursor is automatically closed and None is returned.
         """
         try:
-            row = yield from self._cursor.fetchone()
+            row = await self._cursor.fetchone()
         except AttributeError:
             self._non_result()
         else:
             if row is not None:
                 return self._process_rows([row])[0]
             else:
-                yield from self.close()
+                await self.close()
                 return None
 
-    @asyncio.coroutine
-    def fetchmany(self, size=None):
+    async def fetchmany(self, size=None):
         """Fetch many rows, just like DB-API
         cursor.fetchmany(size=cursor.arraysize).
 
@@ -409,19 +403,18 @@ class ResultProxy:
         """
         try:
             if size is None:
-                rows = yield from self._cursor.fetchmany()
+                rows = await self._cursor.fetchmany()
             else:
-                rows = yield from self._cursor.fetchmany(size)
+                rows = await self._cursor.fetchmany(size)
         except AttributeError:
             self._non_result()
         else:
             ret = self._process_rows(rows)
             if len(ret) == 0:
-                yield from self.close()
+                await self.close()
             return ret
 
-    @asyncio.coroutine
-    def first(self):
+    async def first(self):
         """Fetch the first row and then close the result set unconditionally.
 
         Returns None if no row is present.
@@ -429,31 +422,27 @@ class ResultProxy:
         if self._metadata is None:
             self._non_result()
         try:
-            return (yield from self.fetchone())
+            return (await self.fetchone())
         finally:
-            yield from self.close()
+            await self.close()
 
-    @asyncio.coroutine
-    def scalar(self):
+    async def scalar(self):
         """Fetch the first column of the first row, and close the result set.
 
         Returns None if no row is present.
         """
-        row = yield from self.first()
+        row = await self.first()
         if row is not None:
             return row[0]
         else:
             return None
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+    async def __aiter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __anext__(self):
-            data = yield from self.fetchone()
-            if data is not None:
-                return data
-            else:
-                raise StopAsyncIteration  # noqa
+    async def __anext__(self):
+        data = await self.fetchone()
+        if data is not None:
+            return data
+        else:
+            raise StopAsyncIteration  # noqa

--- a/aiomysql/sa/transaction.py
+++ b/aiomysql/sa/transaction.py
@@ -3,7 +3,6 @@
 import asyncio
 
 from . import exc
-from ..utils import PY_35
 
 
 class Transaction(object):
@@ -44,8 +43,7 @@ class Transaction(object):
         """Return transaction's connection (SAConnection instance)."""
         return self._connection
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         """Close this transaction.
 
         If this transaction is the base transaction in a begin/commit
@@ -58,47 +56,40 @@ class Transaction(object):
         if not self._parent._is_active:
             return
         if self._parent is self:
-            yield from self.rollback()
+            await self.rollback()
         else:
             self._is_active = False
 
-    @asyncio.coroutine
-    def rollback(self):
+    async def rollback(self):
         """Roll back this transaction."""
         if not self._parent._is_active:
             return
-        yield from self._do_rollback()
+        await self._do_rollback()
         self._is_active = False
 
-    @asyncio.coroutine
-    def _do_rollback(self):
-        yield from self._parent.rollback()
+    async def _do_rollback(self):
+        await self._parent.rollback()
 
-    @asyncio.coroutine
-    def commit(self):
+    async def commit(self):
         """Commit this transaction."""
 
         if not self._parent._is_active:
             raise exc.InvalidRequestError("This transaction is inactive")
-        yield from self._do_commit()
+        await self._do_commit()
         self._is_active = False
 
-    @asyncio.coroutine
-    def _do_commit(self):
+    async def _do_commit(self):
         pass
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aenter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc_val, exc_tb):
-            if exc_type:
-                yield from self.rollback()
-            else:
-                if self._is_active:
-                    yield from self.commit()
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            await self.rollback()
+        else:
+            if self._is_active:
+                await self.commit()
 
 
 class RootTransaction(Transaction):
@@ -106,13 +97,11 @@ class RootTransaction(Transaction):
     def __init__(self, connection):
         super().__init__(connection, None)
 
-    @asyncio.coroutine
-    def _do_rollback(self):
-        yield from self._connection._rollback_impl()
+    async def _do_rollback(self):
+        await self._connection._rollback_impl()
 
-    @asyncio.coroutine
-    def _do_commit(self):
-        yield from self._connection._commit_impl()
+    async def _do_commit(self):
+        await self._connection._commit_impl()
 
 
 class NestedTransaction(Transaction):
@@ -129,18 +118,16 @@ class NestedTransaction(Transaction):
     def __init__(self, connection, parent):
         super(NestedTransaction, self).__init__(connection, parent)
 
-    @asyncio.coroutine
-    def _do_rollback(self):
+    async def _do_rollback(self):
         assert self._savepoint is not None, "Broken transaction logic"
         if self._is_active:
-            yield from self._connection._rollback_to_savepoint_impl(
+            await self._connection._rollback_to_savepoint_impl(
                 self._savepoint, self._parent)
 
-    @asyncio.coroutine
-    def _do_commit(self):
+    async def _do_commit(self):
         assert self._savepoint is not None, "Broken transaction logic"
         if self._is_active:
-            yield from self._connection._release_savepoint_impl(
+            await self._connection._release_savepoint_impl(
                 self._savepoint, self._parent)
 
 
@@ -164,8 +151,7 @@ class TwoPhaseTransaction(Transaction):
         """Returns twophase transaction id."""
         return self._xid
 
-    @asyncio.coroutine
-    def prepare(self):
+    async def prepare(self):
         """Prepare this TwoPhaseTransaction.
 
         After a PREPARE, the transaction can be committed.
@@ -173,15 +159,13 @@ class TwoPhaseTransaction(Transaction):
 
         if not self._parent.is_active:
             raise exc.InvalidRequestError("This transaction is inactive")
-        yield from self._connection._prepare_twophase_impl(self._xid)
+        await self._connection._prepare_twophase_impl(self._xid)
         self._is_prepared = True
 
-    @asyncio.coroutine
-    def _do_rollback(self):
-        yield from self._connection.rollback_prepared(
+    async def _do_rollback(self):
+        await self._connection.rollback_prepared(
             self._xid, is_prepared=self._is_prepared)
 
-    @asyncio.coroutine
-    def _do_commit(self):
-        yield from self._connection.commit_prepared(
+    async def _do_commit(self):
+        await self._connection.commit_prepared(
             self._xid, is_prepared=self._is_prepared)

--- a/aiomysql/sa/transaction.py
+++ b/aiomysql/sa/transaction.py
@@ -1,7 +1,5 @@
 # ported from:
 # https://github.com/aio-libs/aiopg/blob/master/aiopg/sa/transaction.py
-import asyncio
-
 from . import exc
 
 

--- a/aiomysql/utils.py
+++ b/aiomysql/utils.py
@@ -58,9 +58,8 @@ class _ContextManager(Coroutine):
     def __next__(self):
         return self.send(None)
 
-    async def __aiter__(self):
-        resp = await self._coro
-        return resp
+    def __iter__(self):
+        return self._coro.__await__()
 
     def __await__(self):
         return self._coro.__await__()

--- a/aiomysql/utils.py
+++ b/aiomysql/utils.py
@@ -1,13 +1,6 @@
 import asyncio
-import sys
 
-
-PY_35 = sys.version_info >= (3, 5)
-if PY_35:
-    from collections.abc import Coroutine
-    base = Coroutine
-else:
-    base = object
+from collections.abc import Coroutine
 
 
 def create_future(loop):
@@ -28,7 +21,7 @@ def create_task(coro, loop):
         return asyncio.Task(coro, loop=loop)
 
 
-class _ContextManager(base):
+class _ContextManager(Coroutine):
 
     __slots__ = ('_coro', '_obj')
 
@@ -65,70 +58,52 @@ class _ContextManager(base):
     def __next__(self):
         return self.send(None)
 
-    @asyncio.coroutine
-    def __iter__(self):
-        resp = yield from self._coro
+    async def __aiter__(self):
+        resp = await self._coro
         return resp
 
-    if PY_35:  # pragma: no branch
-        def __await__(self):
-            resp = yield from self._coro
-            return resp
+    def __await__(self):
+        return self._coro.__await__()
 
-        @asyncio.coroutine
-        def __aenter__(self):
-            self._obj = yield from self._coro
-            return self._obj
+    async def __aenter__(self):
+        self._obj = await self._coro
+        return self._obj
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc, tb):
-            yield from self._obj.close()
-            self._obj = None
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._obj.close()
+        self._obj = None
 
 
 class _ConnectionContextManager(_ContextManager):
-
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc, tb):
-            if exc_type is not None:
-                self._obj.close()
-            else:
-                yield from self._obj.ensure_closed()
-            self._obj = None
+    async def __aexit__(self, exc_type, exc, tb):
+        if exc_type is not None:
+            self._obj.close()
+        else:
+            await self._obj.ensure_closed()
+        self._obj = None
 
 
 class _PoolContextManager(_ContextManager):
-
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc, tb):
-            self._obj.close()
-            yield from self._obj.wait_closed()
-            self._obj = None
+    async def __aexit__(self, exc_type, exc, tb):
+        self._obj.close()
+        await self._obj.wait_closed()
+        self._obj = None
 
 
 class _SAConnectionContextManager(_ContextManager):
-
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aiter__(self):
-            result = yield from self._coro
-            return result
+    async def __aiter__(self):
+        result = await self._coro
+        return result
 
 
 class _TransactionContextManager(_ContextManager):
-
-    if PY_35:  # pragma: no branch
-
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc, tb):
-            if exc_type:
-                yield from self._obj.rollback()
-            else:
-                if self._obj.is_active:
-                    yield from self._obj.commit()
-            self._obj = None
+    async def __aexit__(self, exc_type, exc, tb):
+        if exc_type:
+            await self._obj.rollback()
+        else:
+            if self._obj.is_active:
+                await self._obj.commit()
+        self._obj = None
 
 
 class _PoolAcquireContextManager(_ContextManager):
@@ -140,19 +115,16 @@ class _PoolAcquireContextManager(_ContextManager):
         self._conn = None
         self._pool = pool
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aenter__(self):
-            self._conn = yield from self._coro
-            return self._conn
+    async def __aenter__(self):
+        self._conn = await self._coro
+        return self._conn
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc, tb):
-            try:
-                yield from self._pool.release(self._conn)
-            finally:
-                self._pool = None
-                self._conn = None
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            await self._pool.release(self._conn)
+        finally:
+            self._pool = None
+            self._conn = None
 
 
 class _PoolConnectionContextManager:
@@ -187,25 +159,20 @@ class _PoolConnectionContextManager:
             self._pool = None
             self._conn = None
 
-    if PY_35:  # pragma: no branch
-        @asyncio.coroutine
-        def __aenter__(self):
-            assert not self._conn
-            self._conn = yield from self._pool.acquire()
-            return self._conn
+    async def __aenter__(self):
+        assert not self._conn
+        self._conn = await self._pool.acquire()
+        return self._conn
 
-        @asyncio.coroutine
-        def __aexit__(self, exc_type, exc_val, exc_tb):
-            try:
-                yield from self._pool.release(self._conn)
-            finally:
-                self._pool = None
-                self._conn = None
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        try:
+            await self._pool.release(self._conn)
+        finally:
+            self._pool = None
+            self._conn = None
 
 
-if not PY_35:
-    try:
-        from asyncio import coroutines
-        coroutines._COROUTINE_TYPES += (_ContextManager,)
-    except Exception:
-        pass
+try:
+    asyncio.coroutines._COROUTINE_TYPES += (_ContextManager,)
+except Exception:
+    pass

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -30,37 +30,35 @@ class TestSAConnection(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
-    @asyncio.coroutine
-    def connect(self, **kwargs):
-        conn = yield from connect(db=self.db,
+    async def connect(self, **kwargs):
+        conn = await connect(db=self.db,
                                   user=self.user,
                                   password=self.password,
                                   host=self.host,
                                   loop=self.loop,
                                   port=self.port,
                                   **kwargs)
-        yield from conn.autocommit(True)
-        cur = yield from conn.cursor()
-        yield from cur.execute("DROP TABLE IF EXISTS sa_tbl")
-        yield from cur.execute("CREATE TABLE sa_tbl "
+        await conn.autocommit(True)
+        cur = await conn.cursor()
+        await cur.execute("DROP TABLE IF EXISTS sa_tbl")
+        await cur.execute("CREATE TABLE sa_tbl "
                                "(id serial, name varchar(255))")
-        yield from cur.execute("INSERT INTO sa_tbl (name)"
+        await cur.execute("INSERT INTO sa_tbl (name)"
                                "VALUES ('first')")
 
-        yield from cur._connection.commit()
+        await cur._connection.commit()
         # yield from cur.close()
         engine = mock.Mock()
         engine.dialect = sa.engine._dialect
         return sa.SAConnection(conn, engine)
 
     def test_execute_text_select(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute("SELECT * FROM sa_tbl;")
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute("SELECT * FROM sa_tbl;")
             self.assertIsInstance(res.cursor, Cursor)
             self.assertEqual(('id', 'name'), res.keys())
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
             self.assertEqual(1, len(rows))
@@ -72,17 +70,16 @@ class TestSAConnection(unittest.TestCase):
             self.assertEqual('first', row['name'])
             self.assertEqual('first', row.name)
             # TODO: fix this
-            yield from conn._connection.commit()
+            await conn._connection.commit()
         self.loop.run_until_complete(go())
 
     def test_execute_sa_select(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.select())
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.select())
             self.assertIsInstance(res.cursor, Cursor)
             self.assertEqual(('id', 'name'), res.keys())
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
             self.assertTrue(res.returns_rows)
@@ -96,18 +93,17 @@ class TestSAConnection(unittest.TestCase):
             self.assertEqual('first', row['name'])
             self.assertEqual('first', row.name)
             # TODO: fix this
-            yield from conn._connection.commit()
+            await conn._connection.commit()
 
         self.loop.run_until_complete(go())
 
     def test_execute_sa_insert_with_dict(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert(), {"id": 2, "name": "second"})
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert(), {"id": 2, "name": "second"})
 
-            res = yield from conn.execute(tbl.select())
-            rows = list(res)
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual((1, 'first'), rows[0])
             self.assertEqual((2, 'second'), rows[1])
@@ -115,13 +111,12 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_execute_sa_insert_with_tuple(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert(), (2, "second"))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert(), (2, "second"))
 
-            res = yield from conn.execute(tbl.select())
-            rows = list(res)
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual((1, 'first'), rows[0])
             self.assertEqual((2, 'second'), rows[1])
@@ -129,13 +124,12 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_execute_sa_insert_named_params(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert(), id=2, name="second")
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert(), id=2, name="second")
 
-            res = yield from conn.execute(tbl.select())
-            rows = list(res)
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual((1, 'first'), rows[0])
             self.assertEqual((2, 'second'), rows[1])
@@ -143,13 +137,12 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_execute_sa_insert_positional_params(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert(), 2, "second")
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert(), 2, "second")
 
-            res = yield from conn.execute(tbl.select())
-            rows = list(res)
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual((1, 'first'), rows[0])
             self.assertEqual((2, 'second'), rows[1])
@@ -157,34 +150,31 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_scalar(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.scalar(tbl.count())
+        async def go():
+            conn = await self.connect()
+            res = await conn.scalar(tbl.count())
             self.assertEqual(1, res)
 
         self.loop.run_until_complete(go())
 
     def test_scalar_None(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.delete())
-            res = yield from conn.scalar(tbl.select())
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.delete())
+            res = await conn.scalar(tbl.select())
             self.assertIsNone(res)
             # TODO: fix this
-            yield from conn._connection.commit()
+            await conn._connection.commit()
 
         self.loop.run_until_complete(go())
 
     def test_row_proxy(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.select())
-            rows = [r for r in res]
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             row = rows[0]
-            row2 = yield from (yield from conn.execute(tbl.select())).first()
+            row2 = await (await conn.execute(tbl.select())).first()
             self.assertEqual(2, len(row))
             self.assertEqual(['id', 'name'], list(row))
             self.assertIn('id', row)
@@ -200,111 +190,103 @@ class TestSAConnection(unittest.TestCase):
             self.assertFalse(row2 != row)
             self.assertNotEqual(5, row)
             # TODO: fix this
-            yield from conn._connection.commit()
+            await conn._connection.commit()
 
         self.loop.run_until_complete(go())
 
     def test_insert(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.insert().values(name='second'))
             self.assertEqual(1, res.rowcount)
             self.assertEqual(2, res.lastrowid)
 
         self.loop.run_until_complete(go())
 
     def test_raw_insert(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(
+        async def go():
+            conn = await self.connect()
+            await conn.execute(
                 "INSERT INTO sa_tbl (name) VALUES ('third')")
-            res = yield from conn.execute(tbl.select())
+            res = await conn.execute(tbl.select())
             self.assertEqual(2, res.rowcount)
             self.assertEqual(('id', 'name'), res.keys())
             self.assertTrue(res.returns_rows)
 
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual(2, rows[1].id)
         self.loop.run_until_complete(go())
 
     def test_raw_insert_with_params(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(
                 "INSERT INTO sa_tbl (id, name) VALUES (%s, %s)",
                 2, 'third')
-            res = yield from conn.execute(tbl.select())
+            res = await conn.execute(tbl.select())
             self.assertEqual(2, res.rowcount)
             self.assertEqual(('id', 'name'), res.keys())
             self.assertTrue(res.returns_rows)
 
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual(2, rows[1].id)
         self.loop.run_until_complete(go())
 
     def test_raw_insert_with_params_dict(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(
                 "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
                 {'id': 2, 'name': 'third'})
-            res = yield from conn.execute(tbl.select())
+            res = await conn.execute(tbl.select())
             self.assertEqual(2, res.rowcount)
             self.assertEqual(('id', 'name'), res.keys())
             self.assertTrue(res.returns_rows)
 
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual(2, rows[1].id)
         self.loop.run_until_complete(go())
 
     def test_raw_insert_with_named_params(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(
                 "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
                 id=2, name='third')
-            res = yield from conn.execute(tbl.select())
+            res = await conn.execute(tbl.select())
             self.assertEqual(2, res.rowcount)
             self.assertEqual(('id', 'name'), res.keys())
             self.assertTrue(res.returns_rows)
 
-            rows = [r for r in res]
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertEqual(2, rows[1].id)
         self.loop.run_until_complete(go())
 
     def test_raw_insert_with_executemany(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
+        async def go():
+            conn = await self.connect()
             with self.assertRaises(sa.ArgumentError):
-                yield from conn.execute(
+                await conn.execute(
                     "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
                     [(2, 'third'), (3, 'forth')])
         self.loop.run_until_complete(go())
 
     def test_raw_select_with_wildcard(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(
+        async def go():
+            conn = await self.connect()
+            await conn.execute(
                 'SELECT * FROM sa_tbl WHERE name LIKE "%test%"')
         self.loop.run_until_complete(go())
 
     def test_delete(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
+        async def go():
+            conn = await self.connect()
 
-            res = yield from conn.execute(tbl.delete().where(tbl.c.id == 1))
+            res = await conn.execute(tbl.delete().where(tbl.c.id == 1))
 
             self.assertEqual((), res.keys())
             self.assertEqual(1, res.rowcount)
@@ -315,14 +297,13 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_double_close(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute("SELECT 1")
-            yield from res.close()
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute("SELECT 1")
+            await res.close()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
-            yield from res.close()
+            await res.close()
             self.assertTrue(res.closed)
             self.assertIsNone(res.cursor)
 
@@ -330,11 +311,10 @@ class TestSAConnection(unittest.TestCase):
 
     @unittest.skip("Find out how to close cursor on __del__ method")
     def test_weakrefs(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
+        async def go():
+            conn = await self.connect()
             self.assertEqual(0, len(conn._weak_results))
-            res = yield from conn.execute("SELECT 1")
+            res = await conn.execute("SELECT 1")
             self.assertEqual(1, len(conn._weak_results))
             cur = res.cursor
             self.assertFalse(cur.closed)
@@ -347,13 +327,12 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_fetchall(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            rows = yield from res.fetchall()
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchall()
             self.assertEqual(2, len(rows))
             self.assertTrue(res.closed)
             self.assertTrue(res.returns_rows)
@@ -362,59 +341,54 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_fetchall_closed(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            yield from res.close()
+            res = await conn.execute(tbl.select())
+            await res.close()
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchall()
+                await res.fetchall()
 
         self.loop.run_until_complete(go())
 
     def test_fetchall_not_returns_rows(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.delete())
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.delete())
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchall()
+                await res.fetchall()
 
         self.loop.run_until_complete(go())
 
     def test_fetchone_closed(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            yield from res.close()
+            res = await conn.execute(tbl.select())
+            await res.close()
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchone()
+                await res.fetchone()
 
         self.loop.run_until_complete(go())
 
     def test_first_not_returns_rows(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.delete())
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.delete())
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.first()
+                await res.first()
 
         self.loop.run_until_complete(go())
 
     def test_fetchmany(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            rows = yield from res.fetchmany()
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchmany()
             self.assertEqual(1, len(rows))
             self.assertFalse(res.closed)
             self.assertTrue(res.returns_rows)
@@ -423,13 +397,12 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_fetchmany_with_size(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            rows = yield from res.fetchmany(100)
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchmany(100)
             self.assertEqual(2, len(rows))
             self.assertFalse(res.closed)
             self.assertTrue(res.returns_rows)
@@ -438,74 +411,69 @@ class TestSAConnection(unittest.TestCase):
         self.loop.run_until_complete(go())
 
     def test_fetchmany_closed(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            yield from res.close()
+            res = await conn.execute(tbl.select())
+            await res.close()
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchmany()
+                await res.fetchmany()
 
         self.loop.run_until_complete(go())
 
     def test_fetchmany_with_size_closed(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            yield from conn.execute(tbl.insert().values(name='second'))
+        async def go():
+            conn = await self.connect()
+            await conn.execute(tbl.insert().values(name='second'))
 
-            res = yield from conn.execute(tbl.select())
-            yield from res.close()
+            res = await conn.execute(tbl.select())
+            await res.close()
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchmany(5555)
+                await res.fetchmany(5555)
 
         self.loop.run_until_complete(go())
 
     def test_fetchmany_not_returns_rows(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(tbl.delete())
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(tbl.delete())
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchmany()
+                await res.fetchmany()
 
         self.loop.run_until_complete(go())
 
     def test_fetchmany_close_after_last_read(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
+        async def go():
+            conn = await self.connect()
 
-            res = yield from conn.execute(tbl.select())
-            rows = yield from res.fetchmany()
+            res = await conn.execute(tbl.select())
+            rows = await res.fetchmany()
             self.assertEqual(1, len(rows))
             self.assertFalse(res.closed)
             self.assertTrue(res.returns_rows)
             self.assertEqual([(1, 'first')], rows)
-            rows2 = yield from res.fetchmany()
+            rows2 = await res.fetchmany()
             self.assertEqual(0, len(rows2))
             self.assertTrue(res.closed)
 
         self.loop.run_until_complete(go())
 
     def test_create_table(self, **kwargs):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            res = yield from conn.execute(DropTable(tbl))
+        async def go():
+            conn = await self.connect()
+            res = await conn.execute(DropTable(tbl))
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchmany()
+                await res.fetchmany()
 
             with self.assertRaises(aiomysql.ProgrammingError):
-                yield from conn.execute("SELECT * FROM sa_tbl")
+                await conn.execute("SELECT * FROM sa_tbl")
 
-            res = yield from conn.execute(CreateTable(tbl))
+            res = await conn.execute(CreateTable(tbl))
             with self.assertRaises(sa.ResourceClosedError):
-                yield from res.fetchmany()
+                await res.fetchmany()
 
-            res = yield from conn.execute("SELECT * FROM sa_tbl")
-            self.assertEqual(0, len(list(res)))
+            res = await conn.execute("SELECT * FROM sa_tbl")
+            self.assertEqual(0, len(await res.fetchall()))
 
         self.loop.run_until_complete(go())

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -32,19 +32,19 @@ class TestSAConnection(unittest.TestCase):
 
     async def connect(self, **kwargs):
         conn = await connect(db=self.db,
-                                  user=self.user,
-                                  password=self.password,
-                                  host=self.host,
-                                  loop=self.loop,
-                                  port=self.port,
-                                  **kwargs)
+                             user=self.user,
+                             password=self.password,
+                             host=self.host,
+                             loop=self.loop,
+                             port=self.port,
+                             **kwargs)
         await conn.autocommit(True)
         cur = await conn.cursor()
         await cur.execute("DROP TABLE IF EXISTS sa_tbl")
         await cur.execute("CREATE TABLE sa_tbl "
-                               "(id serial, name varchar(255))")
+                          "(id serial, name varchar(255))")
         await cur.execute("INSERT INTO sa_tbl (name)"
-                               "VALUES ('first')")
+                          "VALUES ('first')")
 
         await cur._connection.commit()
         # yield from cur.close()

--- a/tests/sa/test_sa_engine.py
+++ b/tests/sa/test_sa_engine.py
@@ -34,27 +34,27 @@ class TestEngine(unittest.TestCase):
     async def make_engine(self, use_loop=True, **kwargs):
         if use_loop:
             return (await sa.create_engine(db=self.db,
-                                                user=self.user,
-                                                password=self.password,
-                                                host=self.host,
-                                                port=self.port,
-                                                loop=self.loop,
-                                                minsize=10,
-                                                **kwargs))
+                                           user=self.user,
+                                           password=self.password,
+                                           host=self.host,
+                                           port=self.port,
+                                           loop=self.loop,
+                                           minsize=10,
+                                           **kwargs))
         else:
             return (await sa.create_engine(db=self.db,
-                                                user=self.user,
-                                                password=self.password,
-                                                host=self.host,
-                                                port=self.port,
-                                                minsize=10,
-                                                **kwargs))
+                                           user=self.user,
+                                           password=self.password,
+                                           host=self.host,
+                                           port=self.port,
+                                           minsize=10,
+                                           **kwargs))
 
     async def start(self):
         async with self.engine.acquire() as conn:
             await conn.execute("DROP TABLE IF EXISTS sa_tbl3")
             await conn.execute("CREATE TABLE sa_tbl3 "
-                                    "(id serial, name varchar(255))")
+                               "(id serial, name varchar(255))")
 
     def test_dialect(self):
         self.assertEqual(sa.engine._dialect, self.engine.dialect)
@@ -156,10 +156,8 @@ class TestEngine(unittest.TestCase):
                 ops.append('wait_closed')
 
             engine.close()
-            await asyncio.gather(wait_closed(),
-                                      do_release(c1),
-                                      do_release(c2),
-                                      loop=self.loop)
+            await asyncio.gather(wait_closed(), do_release(c1),
+                                 do_release(c2), loop=self.loop)
             self.assertEqual(['release', 'release', 'wait_closed'], ops)
             self.assertEqual(0, engine.freesize)
             engine.close()

--- a/tests/sa/test_sa_transaction.py
+++ b/tests/sa/test_sa_transaction.py
@@ -46,19 +46,19 @@ class TestTransaction(unittest.TestCase):
         conn = await self.connect(**kwargs)
         await conn.execute("DROP TABLE IF EXISTS sa_tbl2")
         await conn.execute("CREATE TABLE sa_tbl2 "
-                                "(id serial, name varchar(255))")
+                           "(id serial, name varchar(255))")
         await conn.execute("INSERT INTO sa_tbl2 (name)"
-                                "VALUES ('first')")
+                           "VALUES ('first')")
         await conn._connection.commit()
 
     async def connect(self, **kwargs):
         conn = await connect(db=self.db,
-                                  user=self.user,
-                                  password=self.password,
-                                  host=self.host,
-                                  port=self.port,
-                                  loop=self.loop,
-                                  **kwargs)
+                             user=self.user,
+                             password=self.password,
+                             host=self.host,
+                             port=self.port,
+                             loop=self.loop,
+                             **kwargs)
         # TODO: fix this, should autocommit be enabled by default?
         await conn.autocommit(True)
         engine = mock.Mock()

--- a/tests/sa/test_sa_transaction.py
+++ b/tests/sa/test_sa_transaction.py
@@ -17,9 +17,9 @@ tbl = Table('sa_tbl2', meta,
 
 def check_prepared_transactions(func):
     @functools.wraps(func)
-    def wrapper(self):
-        conn = yield from self.loop.run_until_complete(self._connect())
-        val = yield from conn.scalar('show max_prepared_transactions')
+    async def wrapper(self):
+        conn = await self.loop.run_until_complete(self._connect())
+        val = await conn.scalar('show max_prepared_transactions')
         if not val:
             raise unittest.SkipTest('Twophase transacions are not supported. '
                                     'Set max_prepared_transactions to '
@@ -42,19 +42,17 @@ class TestTransaction(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
-    @asyncio.coroutine
-    def start(self, **kwargs):
-        conn = yield from self.connect(**kwargs)
-        yield from conn.execute("DROP TABLE IF EXISTS sa_tbl2")
-        yield from conn.execute("CREATE TABLE sa_tbl2 "
+    async def start(self, **kwargs):
+        conn = await self.connect(**kwargs)
+        await conn.execute("DROP TABLE IF EXISTS sa_tbl2")
+        await conn.execute("CREATE TABLE sa_tbl2 "
                                 "(id serial, name varchar(255))")
-        yield from conn.execute("INSERT INTO sa_tbl2 (name)"
+        await conn.execute("INSERT INTO sa_tbl2 (name)"
                                 "VALUES ('first')")
-        yield from conn._connection.commit()
+        await conn._connection.commit()
 
-    @asyncio.coroutine
-    def connect(self, **kwargs):
-        conn = yield from connect(db=self.db,
+    async def connect(self, **kwargs):
+        conn = await connect(db=self.db,
                                   user=self.user,
                                   password=self.password,
                                   host=self.host,
@@ -62,7 +60,7 @@ class TestTransaction(unittest.TestCase):
                                   loop=self.loop,
                                   **kwargs)
         # TODO: fix this, should autocommit be enabled by default?
-        yield from conn.autocommit(True)
+        await conn.autocommit(True)
         engine = mock.Mock()
         engine.dialect = sa.engine._dialect
 
@@ -74,393 +72,374 @@ class TestTransaction(unittest.TestCase):
         return ret
 
     def test_without_transactions(self):
-        @asyncio.coroutine
-        def go():
-            conn1 = yield from self.connect()
-            conn2 = yield from self.connect()
-            res1 = yield from conn1.scalar(tbl.count())
+        async def go():
+            conn1 = await self.connect()
+            conn2 = await self.connect()
+            res1 = await conn1.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from conn2.execute(tbl.delete())
+            await conn2.execute(tbl.delete())
 
-            res2 = yield from conn1.scalar(tbl.count())
+            res2 = await conn1.scalar(tbl.count())
             self.assertEqual(0, res2)
-            yield from conn1.close()
-            yield from conn2.close()
+            await conn1.close()
+            await conn2.close()
 
         self.loop.run_until_complete(go())
 
     def test_connection_attr(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin()
             self.assertIs(tr.connection, conn)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction(self):
-        @asyncio.coroutine
-        def go():
-            conn1 = yield from self.connect()
-            conn2 = yield from self.connect()
+        async def go():
+            conn1 = await self.connect()
+            conn2 = await self.connect()
 
-            tr = yield from conn1.begin()
+            tr = await conn1.begin()
             self.assertTrue(tr.is_active)
-            yield from conn1.execute(tbl.delete())
+            await conn1.execute(tbl.delete())
 
-            res1 = yield from conn2.scalar(tbl.count())
+            res1 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from tr.commit()
+            await tr.commit()
 
             self.assertFalse(tr.is_active)
             self.assertFalse(conn1.in_transaction)
-            res2 = yield from conn2.scalar(tbl.count())
+            res2 = await conn2.scalar(tbl.count())
             self.assertEqual(0, res2)
-            yield from conn1.close()
-            yield from conn2.close()
+            await conn1.close()
+            await conn2.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction_rollback(self):
-        @asyncio.coroutine
-        def go():
-            conn1 = yield from self.connect()
-            conn2 = yield from self.connect()
+        async def go():
+            conn1 = await self.connect()
+            conn2 = await self.connect()
 
-            tr = yield from conn1.begin()
+            tr = await conn1.begin()
             self.assertTrue(tr.is_active)
-            yield from conn1.execute(tbl.delete())
+            await conn1.execute(tbl.delete())
 
-            res1 = yield from conn2.scalar(tbl.count())
+            res1 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from tr.rollback()
+            await tr.rollback()
 
             self.assertFalse(tr.is_active)
-            res2 = yield from conn2.scalar(tbl.count())
+            res2 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res2)
-            yield from conn1.close()
-            yield from conn2.close()
+            await conn1.close()
+            await conn2.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction_close(self):
-        @asyncio.coroutine
-        def go():
-            conn1 = yield from self.connect()
-            conn2 = yield from self.connect()
+        async def go():
+            conn1 = await self.connect()
+            conn2 = await self.connect()
 
-            tr = yield from conn1.begin()
+            tr = await conn1.begin()
             self.assertTrue(tr.is_active)
-            yield from conn1.execute(tbl.delete())
+            await conn1.execute(tbl.delete())
 
-            res1 = yield from conn2.scalar(tbl.count())
+            res1 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from tr.close()
+            await tr.close()
 
             self.assertFalse(tr.is_active)
-            res2 = yield from conn2.scalar(tbl.count())
+            res2 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res2)
-            yield from conn1.close()
-            yield from conn2.close()
+            await conn1.close()
+            await conn2.close()
 
         self.loop.run_until_complete(go())
 
     def test_rollback_on_connection_close(self):
-        @asyncio.coroutine
-        def go():
-            conn1 = yield from self.connect()
-            conn2 = yield from self.connect()
+        async def go():
+            conn1 = await self.connect()
+            conn2 = await self.connect()
 
-            tr = yield from conn1.begin()
-            yield from conn1.execute(tbl.delete())
+            tr = await conn1.begin()
+            await conn1.execute(tbl.delete())
 
-            res1 = yield from conn2.scalar(tbl.count())
+            res1 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from conn1.close()
+            await conn1.close()
 
-            res2 = yield from conn2.scalar(tbl.count())
+            res2 = await conn2.scalar(tbl.count())
             self.assertEqual(1, res2)
             del tr
-            yield from conn1.close()
-            yield from conn2.close()
+            await conn1.close()
+            await conn2.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction_commit_inactive(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin()
             self.assertTrue(tr.is_active)
-            yield from tr.commit()
+            await tr.commit()
             self.assertFalse(tr.is_active)
             with self.assertRaises(sa.InvalidRequestError):
-                yield from tr.commit()
-            yield from conn.close()
+                await tr.commit()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction_rollback_inactive(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin()
             self.assertTrue(tr.is_active)
-            yield from tr.rollback()
+            await tr.rollback()
             self.assertFalse(tr.is_active)
-            yield from tr.rollback()
+            await tr.rollback()
             self.assertFalse(tr.is_active)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_root_transaction_double_close(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin()
             self.assertTrue(tr.is_active)
-            yield from tr.close()
+            await tr.close()
             self.assertFalse(tr.is_active)
-            yield from tr.close()
+            await tr.close()
             self.assertFalse(tr.is_active)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_inner_transaction_commit(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin()
-            tr2 = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin()
+            tr2 = await conn.begin()
             self.assertTrue(tr2.is_active)
 
-            yield from tr2.commit()
+            await tr2.commit()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            yield from tr1.commit()
+            await tr1.commit()
             self.assertFalse(tr2.is_active)
             self.assertFalse(tr1.is_active)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_inner_transaction_rollback(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin()
-            tr2 = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin()
+            tr2 = await conn.begin()
             self.assertTrue(tr2.is_active)
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
+            await conn.execute(tbl.insert().values(name='aaaa'))
 
-            yield from tr2.rollback()
+            await tr2.rollback()
             self.assertFalse(tr2.is_active)
             self.assertFalse(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(1, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_inner_transaction_close(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin()
-            tr2 = yield from conn.begin()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin()
+            tr2 = await conn.begin()
             self.assertTrue(tr2.is_active)
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
+            await conn.execute(tbl.insert().values(name='aaaa'))
 
-            yield from tr2.close()
+            await tr2.close()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
-            yield from tr1.commit()
+            await tr1.commit()
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(2, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_nested_transaction_commit(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin_nested()
-            tr2 = yield from conn.begin_nested()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin_nested()
+            tr2 = await conn.begin_nested()
             self.assertTrue(tr1.is_active)
             self.assertTrue(tr2.is_active)
 
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
-            yield from tr2.commit()
+            await conn.execute(tbl.insert().values(name='aaaa'))
+            await tr2.commit()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(2, res)
 
-            yield from tr1.commit()
+            await tr1.commit()
             self.assertFalse(tr2.is_active)
             self.assertFalse(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(2, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_nested_transaction_commit_twice(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin_nested()
-            tr2 = yield from conn.begin_nested()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin_nested()
+            tr2 = await conn.begin_nested()
 
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
-            yield from tr2.commit()
+            await conn.execute(tbl.insert().values(name='aaaa'))
+            await tr2.commit()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            yield from tr2.commit()
+            await tr2.commit()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(2, res)
 
-            yield from tr1.close()
-            yield from conn.close()
+            await tr1.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_nested_transaction_rollback(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin_nested()
-            tr2 = yield from conn.begin_nested()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin_nested()
+            tr2 = await conn.begin_nested()
             self.assertTrue(tr1.is_active)
             self.assertTrue(tr2.is_active)
 
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
-            yield from tr2.rollback()
+            await conn.execute(tbl.insert().values(name='aaaa'))
+            await tr2.rollback()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(1, res)
 
-            yield from tr1.commit()
+            await tr1.commit()
             self.assertFalse(tr2.is_active)
             self.assertFalse(tr1.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(1, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_nested_transaction_rollback_twice(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr1 = yield from conn.begin_nested()
-            tr2 = yield from conn.begin_nested()
+        async def go():
+            conn = await self.connect()
+            tr1 = await conn.begin_nested()
+            tr2 = await conn.begin_nested()
 
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
-            yield from tr2.rollback()
+            await conn.execute(tbl.insert().values(name='aaaa'))
+            await tr2.rollback()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            yield from tr2.rollback()
+            await tr2.rollback()
             self.assertFalse(tr2.is_active)
             self.assertTrue(tr1.is_active)
 
-            yield from tr1.commit()
-            res = yield from conn.scalar(tbl.count())
+            await tr1.commit()
+            res = await conn.scalar(tbl.count())
             self.assertEqual(1, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_twophase_transaction_commit(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin_twophase('sa_twophase')
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin_twophase('sa_twophase')
             self.assertEqual(tr.xid, 'sa_twophase')
-            yield from conn.execute(tbl.insert().values(name='aaaa'))
+            await conn.execute(tbl.insert().values(name='aaaa'))
 
-            yield from tr.prepare()
+            await tr.prepare()
             self.assertTrue(tr.is_active)
 
-            yield from tr.commit()
+            await tr.commit()
             self.assertFalse(tr.is_active)
 
-            res = yield from conn.scalar(tbl.count())
+            res = await conn.scalar(tbl.count())
             self.assertEqual(2, res)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_twophase_transaction_twice(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            tr = yield from conn.begin_twophase()
+        async def go():
+            conn = await self.connect()
+            tr = await conn.begin_twophase()
             with self.assertRaises(sa.InvalidRequestError):
-                yield from conn.begin_twophase()
+                await conn.begin_twophase()
 
             self.assertTrue(tr.is_active)
-            yield from tr.prepare()
-            yield from tr.commit()
-            yield from conn.close()
+            await tr.prepare()
+            await tr.commit()
+            await conn.close()
 
         self.loop.run_until_complete(go())
 
     def test_transactions_sequence(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
+        async def go():
+            conn = await self.connect()
 
-            yield from conn.execute(tbl.delete())
+            await conn.execute(tbl.delete())
 
             self.assertIsNone(conn._transaction)
 
-            tr1 = yield from conn.begin()
+            tr1 = await conn.begin()
             self.assertIs(tr1, conn._transaction)
-            yield from conn.execute(tbl.insert().values(name='a'))
-            res1 = yield from conn.scalar(tbl.count())
+            await conn.execute(tbl.insert().values(name='a'))
+            res1 = await conn.scalar(tbl.count())
             self.assertEqual(1, res1)
 
-            yield from tr1.commit()
+            await tr1.commit()
             self.assertIsNone(conn._transaction)
 
-            tr2 = yield from conn.begin()
+            tr2 = await conn.begin()
             self.assertIs(tr2, conn._transaction)
-            yield from conn.execute(tbl.insert().values(name='b'))
-            res2 = yield from conn.scalar(tbl.count())
+            await conn.execute(tbl.insert().values(name='b'))
+            res2 = await conn.scalar(tbl.count())
             self.assertEqual(2, res2)
-            yield from tr2.rollback()
+            await tr2.rollback()
             self.assertIsNone(conn._transaction)
 
-            tr3 = yield from conn.begin()
+            tr3 = await conn.begin()
             self.assertIs(tr3, conn._transaction)
-            yield from conn.execute(tbl.insert().values(name='b'))
-            res3 = yield from conn.scalar(tbl.count())
+            await conn.execute(tbl.insert().values(name='b'))
+            res3 = await conn.scalar(tbl.count())
             self.assertEqual(2, res3)
-            yield from tr3.commit()
+            await tr3.commit()
             self.assertIsNone(conn._transaction)
-            yield from conn.close()
+            await conn.close()
 
         self.loop.run_until_complete(go())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -97,7 +97,7 @@ async def test_string(cursor, table_cleanup):
     test_value = "I am a test string"
     table_cleanup('test_string')
     await cursor.execute("INSERT INTO test_string (a) VALUES (%s)",
-                              test_value)
+                         test_value)
     await cursor.execute("SELECT a FROM test_string")
     r = await cursor.fetchone()
     assert (test_value,) == r
@@ -109,7 +109,7 @@ async def test_integer(cursor, table_cleanup):
     table_cleanup('test_integer')
     test_value = 12345
     await cursor.execute("INSERT INTO test_integer (a) VALUES (%s)",
-                              test_value)
+                         test_value)
     await cursor.execute("SELECT a FROM test_integer")
     r = await cursor.fetchone()
     assert (test_value,) == r
@@ -121,7 +121,7 @@ async def test_binary_data(cursor, table_cleanup):
     await cursor.execute("CREATE TABLE test_blob (b blob)")
     table_cleanup('test_blob')
     await cursor.execute("INSERT INTO test_blob (b) VALUES (%s)",
-                              (data,))
+                         (data,))
     await cursor.execute("SELECT b FROM test_blob")
     (r,) = await cursor.fetchone()
     assert data == r
@@ -158,10 +158,10 @@ async def test_datetime_conversion(cursor, table_cleanup):
     dt = datetime.datetime(2013, 11, 12, 9, 9, 9, 123450)
     try:
         await cursor.execute("CREATE TABLE test_datetime"
-                                  "(id INT, ts DATETIME(6))")
+                             "(id INT, ts DATETIME(6))")
         table_cleanup('test_datetime')
         await cursor.execute("INSERT INTO test_datetime VALUES "
-                                  "(1,'2013-11-12 09:09:09.12345')")
+                             "(1,'2013-11-12 09:09:09.12345')")
         await cursor.execute("SELECT ts FROM test_datetime")
         r = await cursor.fetchone()
         assert (dt,) == r
@@ -196,14 +196,14 @@ async def test_get_transaction_status(connection, cursor):
 async def test_rollback(connection, cursor):
     await cursor.execute('DROP TABLE IF EXISTS tz_data;')
     await cursor.execute('CREATE TABLE tz_data ('
-                              'region VARCHAR(64),'
-                              'zone VARCHAR(64),'
-                              'name VARCHAR(64))')
+                         'region VARCHAR(64),'
+                         'zone VARCHAR(64),'
+                         'name VARCHAR(64))')
     await connection.commit()
 
     args = ('America', '', 'America/New_York')
     await cursor.execute('INSERT INTO tz_data VALUES (%s, %s, %s)',
-                              args)
+                         args)
     await cursor.execute('SELECT * FROM tz_data;')
     data = await cursor.fetchall()
     assert len(data) == 1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import json
 import re
@@ -11,9 +10,8 @@ from pymysql.err import ProgrammingError
 
 @pytest.fixture
 def datatype_table(loop, cursor, table_cleanup):
-    @asyncio.coroutine
-    def f():
-        yield from cursor.execute(
+    async def f():
+        await cursor.execute(
             "CREATE TABLE test_datatypes (b bit, i int, l bigint, f real, s "
             "varchar(32), u varchar(32), bb blob, d date, dt datetime, "
             "ts timestamp, td time, t time, st datetime)")
@@ -23,7 +21,7 @@ def datatype_table(loop, cursor, table_cleanup):
 
 
 @pytest.mark.run_loop
-def test_datatypes(connection, cursor, datatype_table):
+async def test_datatypes(connection, cursor, datatype_table):
     # insert values
     v = (
         True, -3, 123456789012, 5.7, "hello'\" world",
@@ -33,13 +31,13 @@ def test_datatypes(connection, cursor, datatype_table):
         datetime.datetime.now().replace(microsecond=0),
         datetime.timedelta(5, 6), datetime.time(16, 32),
         time.localtime())
-    yield from cursor.execute(
+    await cursor.execute(
         "INSERT INTO test_datatypes (b,i,l,f,s,u,bb,d,dt,td,t,st) "
         "values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
         v)
-    yield from cursor.execute(
+    await cursor.execute(
         "select b,i,l,f,s,u,bb,d,dt,td,t,st from test_datatypes")
-    r = yield from cursor.fetchone()
+    r = await cursor.fetchone()
     assert util.int2byte(1) == r[0]
     # assert v[1:8] == r[1:8])
     assert v[1:9] == r[1:9]
@@ -55,97 +53,97 @@ def test_datatypes(connection, cursor, datatype_table):
 
 
 @pytest.mark.run_loop
-def test_datatypes_nulls(cursor, datatype_table):
+async def test_datatypes_nulls(cursor, datatype_table):
     # check nulls
-    yield from cursor.execute(
+    await cursor.execute(
         "insert into test_datatypes (b,i,l,f,s,u,bb,d,dt,td,t,st) "
         "values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
         [None] * 12)
-    yield from cursor.execute(
+    await cursor.execute(
         "select b,i,l,f,s,u,bb,d,dt,td,t,st from test_datatypes")
-    r = yield from cursor.fetchone()
+    r = await cursor.fetchone()
     assert tuple([None] * 12) == r
 
 
 @pytest.mark.run_loop
-def test_datatypes_sequence_types(cursor, datatype_table):
+async def test_datatypes_sequence_types(cursor, datatype_table):
     # check sequence type
-    yield from cursor.execute(
+    await cursor.execute(
         "INSERT INTO test_datatypes (i, l) VALUES (2,4), (6,8), "
         "(10,12)")
-    yield from cursor.execute(
+    await cursor.execute(
         "select l from test_datatypes where i in %s order by i",
         ((2, 6),))
-    r = yield from cursor.fetchall()
+    r = await cursor.fetchall()
     assert ((4,), (8,)) == r
 
 
 @pytest.mark.run_loop
-def test_dict_escaping(cursor, table_cleanup):
+async def test_dict_escaping(cursor, table_cleanup):
     sql = "CREATE TABLE test_dict (a INTEGER, b INTEGER, c INTEGER)"
-    yield from cursor.execute(sql)
+    await cursor.execute(sql)
     table_cleanup('test_dict')
     sql = "INSERT INTO test_dict (a,b,c) VALUES (%(a)s, %(b)s, %(c)s)"
-    yield from cursor.execute(sql, {"a": 1, "b": 2, "c": 3})
-    yield from cursor.execute("SELECT a,b,c FROM test_dict")
-    r = yield from cursor.fetchone()
+    await cursor.execute(sql, {"a": 1, "b": 2, "c": 3})
+    await cursor.execute("SELECT a,b,c FROM test_dict")
+    r = await cursor.fetchone()
     assert (1, 2, 3) == r
 
 
 @pytest.mark.run_loop
-def test_string(cursor, table_cleanup):
-    yield from cursor.execute("DROP TABLE IF EXISTS test_string;")
-    yield from cursor.execute("CREATE TABLE test_string (a text)")
+async def test_string(cursor, table_cleanup):
+    await cursor.execute("DROP TABLE IF EXISTS test_string;")
+    await cursor.execute("CREATE TABLE test_string (a text)")
     test_value = "I am a test string"
     table_cleanup('test_string')
-    yield from cursor.execute("INSERT INTO test_string (a) VALUES (%s)",
+    await cursor.execute("INSERT INTO test_string (a) VALUES (%s)",
                               test_value)
-    yield from cursor.execute("SELECT a FROM test_string")
-    r = yield from cursor.fetchone()
+    await cursor.execute("SELECT a FROM test_string")
+    r = await cursor.fetchone()
     assert (test_value,) == r
 
 
 @pytest.mark.run_loop
-def test_integer(cursor, table_cleanup):
-    yield from cursor.execute("CREATE TABLE test_integer (a INTEGER)")
+async def test_integer(cursor, table_cleanup):
+    await cursor.execute("CREATE TABLE test_integer (a INTEGER)")
     table_cleanup('test_integer')
     test_value = 12345
-    yield from cursor.execute("INSERT INTO test_integer (a) VALUES (%s)",
+    await cursor.execute("INSERT INTO test_integer (a) VALUES (%s)",
                               test_value)
-    yield from cursor.execute("SELECT a FROM test_integer")
-    r = yield from cursor.fetchone()
+    await cursor.execute("SELECT a FROM test_integer")
+    r = await cursor.fetchone()
     assert (test_value,) == r
 
 
 @pytest.mark.run_loop
-def test_binary_data(cursor, table_cleanup):
+async def test_binary_data(cursor, table_cleanup):
     data = bytes(bytearray(range(256)) * 4)
-    yield from cursor.execute("CREATE TABLE test_blob (b blob)")
+    await cursor.execute("CREATE TABLE test_blob (b blob)")
     table_cleanup('test_blob')
-    yield from cursor.execute("INSERT INTO test_blob (b) VALUES (%s)",
+    await cursor.execute("INSERT INTO test_blob (b) VALUES (%s)",
                               (data,))
-    yield from cursor.execute("SELECT b FROM test_blob")
-    (r,) = yield from cursor.fetchone()
+    await cursor.execute("SELECT b FROM test_blob")
+    (r,) = await cursor.fetchone()
     assert data == r
 
 
 @pytest.mark.run_loop
-def test_untyped_convertion_to_null_and_empty_string(cursor):
-    yield from cursor.execute("select null,''")
-    r = yield from cursor.fetchone()
+async def test_untyped_convertion_to_null_and_empty_string(cursor):
+    await cursor.execute("select null,''")
+    r = await cursor.fetchone()
     assert (None, u'') == r
-    yield from cursor.execute("select '',null")
-    r = yield from cursor.fetchone()
+    await cursor.execute("select '',null")
+    r = await cursor.fetchone()
     assert (u'', None) == r
 
 
 @pytest.mark.run_loop
-def test_timedelta_conversion(cursor):
-    yield from cursor.execute(
+async def test_timedelta_conversion(cursor):
+    await cursor.execute(
         "select time('12:30'), time('23:12:59'), time('23:12:59.05100'), "
         "time('-12:30'), time('-23:12:59'), time('-23:12:59.05100'), "
         "time('-00:30')")
-    r = yield from cursor.fetchone()
+    r = await cursor.fetchone()
     assert (datetime.timedelta(0, 45000),
             datetime.timedelta(0, 83579),
             datetime.timedelta(0, 83579, 51000),
@@ -156,16 +154,16 @@ def test_timedelta_conversion(cursor):
 
 
 @pytest.mark.run_loop
-def test_datetime_conversion(cursor, table_cleanup):
+async def test_datetime_conversion(cursor, table_cleanup):
     dt = datetime.datetime(2013, 11, 12, 9, 9, 9, 123450)
     try:
-        yield from cursor.execute("CREATE TABLE test_datetime"
+        await cursor.execute("CREATE TABLE test_datetime"
                                   "(id INT, ts DATETIME(6))")
         table_cleanup('test_datetime')
-        yield from cursor.execute("INSERT INTO test_datetime VALUES "
+        await cursor.execute("INSERT INTO test_datetime VALUES "
                                   "(1,'2013-11-12 09:09:09.12345')")
-        yield from cursor.execute("SELECT ts FROM test_datetime")
-        r = yield from cursor.fetchone()
+        await cursor.execute("SELECT ts FROM test_datetime")
+        r = await cursor.fetchone()
         assert (dt,) == r
     except ProgrammingError:
         # User is running a version of MySQL that doesn't support
@@ -174,46 +172,45 @@ def test_datetime_conversion(cursor, table_cleanup):
 
 
 @pytest.mark.run_loop
-def test_get_transaction_status(connection, cursor):
+async def test_get_transaction_status(connection, cursor):
     #  make sure that connection is clean without transactions
     transaction_flag = connection.get_transaction_status()
     assert not transaction_flag
 
     # start transaction
-    yield from connection.begin()
+    await connection.begin()
     # make sure transaction flag is up
     transaction_flag = connection.get_transaction_status()
     assert transaction_flag
 
-    yield from cursor.execute('SELECT 1;')
-    (r, ) = yield from cursor.fetchone()
+    await cursor.execute('SELECT 1;')
+    (r, ) = await cursor.fetchone()
     assert r == 1
-    yield from connection.commit()
+    await connection.commit()
     # make sure that transaction flag is down
     transaction_flag = connection.get_transaction_status()
     assert not transaction_flag
 
 
 @pytest.mark.run_loop
-def test_rollback(connection, cursor):
-
-    yield from cursor.execute('DROP TABLE IF EXISTS tz_data;')
-    yield from cursor.execute('CREATE TABLE tz_data ('
+async def test_rollback(connection, cursor):
+    await cursor.execute('DROP TABLE IF EXISTS tz_data;')
+    await cursor.execute('CREATE TABLE tz_data ('
                               'region VARCHAR(64),'
                               'zone VARCHAR(64),'
                               'name VARCHAR(64))')
-    yield from connection.commit()
+    await connection.commit()
 
     args = ('America', '', 'America/New_York')
-    yield from cursor.execute('INSERT INTO tz_data VALUES (%s, %s, %s)',
+    await cursor.execute('INSERT INTO tz_data VALUES (%s, %s, %s)',
                               args)
-    yield from cursor.execute('SELECT * FROM tz_data;')
-    data = yield from cursor.fetchall()
+    await cursor.execute('SELECT * FROM tz_data;')
+    data = await cursor.fetchall()
     assert len(data) == 1
 
-    yield from connection.rollback()
-    yield from cursor.execute('SELECT * FROM tz_data;')
-    data = yield from cursor.fetchall()
+    await connection.rollback()
+    await cursor.execute('SELECT * FROM tz_data;')
+    data = await cursor.fetchall()
 
     # should not return any rows since no inserts was commited
     assert len(data) == 0
@@ -235,15 +232,15 @@ def mysql_server_is(server_version, version_tuple):
 
 
 @pytest.mark.run_loop
-def test_json(connection_creator, table_cleanup):
-    connection = yield from connection_creator(
+async def test_json(connection_creator, table_cleanup):
+    connection = await connection_creator(
         charset="utf8mb4", autocommit=True)
     server_info = connection.get_server_info()
     if not mysql_server_is(server_info, (5, 7, 0)):
         raise pytest.skip("JSON type is not supported on MySQL <= 5.6")
 
-    cursor = yield from connection.cursor()
-    yield from cursor.execute("""\
+    cursor = await connection.cursor()
+    await cursor.execute("""\
     CREATE TABLE test_json (
         id INT NOT NULL,
         json JSON NOT NULL,
@@ -251,13 +248,13 @@ def test_json(connection_creator, table_cleanup):
     );""")
     table_cleanup("test_json")
     json_str = '{"hello": "こんにちは"}'
-    yield from cursor.execute(
+    await cursor.execute(
         "INSERT INTO test_json (id, `json`) values (42, %s)", (json_str,))
-    yield from cursor.execute("SELECT `json` from `test_json` WHERE `id`=42")
+    await cursor.execute("SELECT `json` from `test_json` WHERE `id`=42")
 
-    r = yield from cursor.fetchone()
+    r = await cursor.fetchone()
     assert json.loads(r[0]) == json.loads(json_str)
 
-    yield from cursor.execute("SELECT CAST(%s AS JSON) AS x", (json_str,))
-    r = yield from cursor.fetchone()
+    await cursor.execute("SELECT CAST(%s AS JSON) AS x", (json_str,))
+    r = await cursor.fetchone()
     assert json.loads(r[0]) == json.loads(json_str)

--- a/tests/test_bulk_inserts.py
+++ b/tests/test_bulk_inserts.py
@@ -113,7 +113,8 @@ async def test_insert_on_duplicate_key_update(cursor, table, assert_records):
 
 
 @pytest.mark.run_loop
-async def test_bulk_insert_with_params_as_dict(cursor, table, assert_dict_records):
+async def test_bulk_insert_with_params_as_dict(cursor, table,
+                                               assert_dict_records):
     data = [
         {
             'id': 0,
@@ -146,7 +147,8 @@ async def test_bulk_insert_with_params_as_dict(cursor, table, assert_dict_record
 
 
 @pytest.mark.run_loop
-async def test_bulk_insert_with_precedence_spaces(cursor, table, assert_records):
+async def test_bulk_insert_with_precedence_spaces(cursor, table,
+                                                  assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45)]
     await cursor.executemany("""
         INSERT INTO bulkinsert (id, name, age, height)
@@ -175,7 +177,8 @@ async def test_bulk_replace(cursor, table, assert_records):
 
 
 @pytest.mark.run_loop
-async def test_bulk_insert_with_semicolon_at_the_end(cursor, table, assert_records):
+async def test_bulk_insert_with_semicolon_at_the_end(cursor, table,
+                                                     assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45)]
     await cursor.executemany(
         "INSERT INTO bulkinsert (id, name, age, height) "

--- a/tests/test_bulk_inserts.py
+++ b/tests/test_bulk_inserts.py
@@ -1,65 +1,60 @@
-import asyncio
-
 import pytest
 from aiomysql import DictCursor
 
 
 @pytest.fixture
 def table(loop, connection, table_cleanup):
-    @asyncio.coroutine
-    def f():
-        cursor = yield from connection.cursor(DictCursor)
+    async def f():
+        cursor = await connection.cursor(DictCursor)
         sql = """CREATE TABLE bulkinsert (id INT(11), name CHAR(20),
                  age INT, height INT, PRIMARY KEY (id))"""
-        yield from cursor.execute(sql)
+        await cursor.execute(sql)
     table_cleanup('bulkinsert')
     loop.run_until_complete(f())
 
 
 @pytest.fixture
 def assert_records(cursor):
-    @asyncio.coroutine
-    def f(data):
-        yield from cursor.execute(
+    async def f(data):
+        await cursor.execute(
             "SELECT id, name, age, height FROM bulkinsert")
-        result = yield from cursor.fetchall()
-        yield from cursor.execute('COMMIT')
+        result = await cursor.fetchall()
+        await cursor.execute('COMMIT')
         assert sorted(data) == sorted(result)
     return f
 
 
 @pytest.fixture
 def assert_dict_records(connection):
-    @asyncio.coroutine
-    def f(data):
-        cursor = yield from connection.cursor(DictCursor)
-        yield from cursor.execute(
+    async def f(data):
+        cursor = await connection.cursor(DictCursor)
+        await cursor.execute(
             "SELECT id, name, age, height FROM bulkinsert")
-        result = yield from cursor.fetchall()
-        yield from cursor.execute('COMMIT')
+        result = await cursor.fetchall()
+        await cursor.execute('COMMIT')
         assert sorted(data, key=lambda k: k['id']) == \
             sorted(result, key=lambda k: k['id'])
     return f
 
 
 @pytest.mark.run_loop
-def test_bulk_insert(cursor, table, assert_records):
+async def test_bulk_insert(cursor, table, assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45), (2, "fred", 100, 180)]
-    yield from cursor.executemany(
+    await cursor.executemany(
         "INSERT INTO bulkinsert (id, name, age, height) "
         "VALUES (%s,%s,%s,%s)", data)
     expected = bytearray(b"INSERT INTO bulkinsert (id, name, age, height) "
                          b"VALUES (0,'bob',21,123),(1,'jim',56,45),"
                          b"(2,'fred',100,180)")
     assert cursor._last_executed == expected
-    yield from cursor.execute('commit')
-    yield from assert_records(data)
+    await cursor.execute('commit')
+    await assert_records(data)
 
 
 @pytest.mark.run_loop
-def test_bulk_insert_multiline_statement(cursor, table, assert_records):
+async def test_bulk_insert_multiline_statement(cursor, table, assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45), (2, "fred", 100, 180)]
-    yield from cursor.executemany("""insert
+    await cursor.executemany("""insert
         into bulkinsert (id, name,
         age, height)
         values (%s,
@@ -76,25 +71,25 @@ def test_bulk_insert_multiline_statement(cursor, table, assert_records):
         45 ),(2,
         'fred' , 100,
         180 )""")
-    yield from cursor.execute('COMMIT')
-    yield from assert_records(data)
+    await cursor.execute('COMMIT')
+    await assert_records(data)
 
 
 @pytest.mark.run_loop
-def test_bulk_insert_single_record(cursor, table, assert_records):
+async def test_bulk_insert_single_record(cursor, table, assert_records):
     data = [(0, "bob", 21, 123)]
-    yield from cursor.executemany(
+    await cursor.executemany(
         "insert into bulkinsert (id, name, age, height) "
         "values (%s,%s,%s,%s)", data)
-    yield from cursor.execute('COMMIT')
-    yield from assert_records(data)
+    await cursor.execute('COMMIT')
+    await assert_records(data)
 
 
 @pytest.mark.run_loop
-def test_insert_on_duplicate_key_update(cursor, table, assert_records):
+async def test_insert_on_duplicate_key_update(cursor, table, assert_records):
     # executemany should work with "insert ... on update" "
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45), (2, "fred", 100, 180)]
-    yield from cursor.executemany("""insert
+    await cursor.executemany("""insert
         into bulkinsert (id, name,
         age, height)
         values (%s,
@@ -113,12 +108,12 @@ def test_insert_on_duplicate_key_update(cursor, table, assert_records):
         'fred' , 100,
         180 ) on duplicate key update
         age = values(age)""")
-    yield from cursor.execute('COMMIT')
-    yield from assert_records(data)
+    await cursor.execute('COMMIT')
+    await assert_records(data)
 
 
 @pytest.mark.run_loop
-def test_bulk_insert_with_params_as_dict(cursor, table, assert_dict_records):
+async def test_bulk_insert_with_params_as_dict(cursor, table, assert_dict_records):
     data = [
         {
             'id': 0,
@@ -139,21 +134,21 @@ def test_bulk_insert_with_params_as_dict(cursor, table, assert_dict_records):
             'height': 180
         },
     ]
-    yield from cursor.executemany(
+    await cursor.executemany(
         "INSERT INTO bulkinsert (id, name, age, height) "
         "VALUES (%(id)s,%(name)s,%(age)s,%(height)s)", data)
     expected = bytearray(b"INSERT INTO bulkinsert (id, name, age, height) "
                          b"VALUES (0,'bob',21,123),(1,'jim',56,45),"
                          b"(2,'fred',100,180)")
     assert cursor._last_executed == expected
-    yield from cursor.execute('commit')
-    yield from assert_dict_records(data)
+    await cursor.execute('commit')
+    await assert_dict_records(data)
 
 
 @pytest.mark.run_loop
-def test_bulk_insert_with_precedence_spaces(cursor, table, assert_records):
+async def test_bulk_insert_with_precedence_spaces(cursor, table, assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45)]
-    yield from cursor.executemany("""
+    await cursor.executemany("""
         INSERT INTO bulkinsert (id, name, age, height)
         VALUES (%s,%s,%s,%s)
     """, data)
@@ -161,32 +156,32 @@ def test_bulk_insert_with_precedence_spaces(cursor, table, assert_records):
                          b"\n        VALUES (0,\'bob\',21,123),"
                          b"(1,\'jim\',56,45)\n    ")
     assert cursor._last_executed == expected
-    yield from cursor.execute('commit')
-    yield from assert_records(data)
+    await cursor.execute('commit')
+    await assert_records(data)
 
 
 @pytest.mark.run_loop
-def test_bulk_replace(cursor, table, assert_records):
+async def test_bulk_replace(cursor, table, assert_records):
     data = [(0, "bob", 21, 123), (0, "jim", 56, 45)]
     sql = ("REPLACE INTO bulkinsert (id, name, age, height) " +
            "VALUES (%s,%s,%s,%s)")
-    yield from cursor.executemany(sql, data)
+    await cursor.executemany(sql, data)
     assert cursor._last_executed.strip() == bytearray(
         b"REPLACE INTO bulkinsert (id, name, age, height) " +
         b"VALUES (0,'bob',21,123),(0,'jim',56,45)"
     )
-    yield from cursor.execute('COMMIT')
-    yield from assert_records([(0, "jim", 56, 45)])
+    await cursor.execute('COMMIT')
+    await assert_records([(0, "jim", 56, 45)])
 
 
 @pytest.mark.run_loop
-def test_bulk_insert_with_semicolon_at_the_end(cursor, table, assert_records):
+async def test_bulk_insert_with_semicolon_at_the_end(cursor, table, assert_records):
     data = [(0, "bob", 21, 123), (1, "jim", 56, 45)]
-    yield from cursor.executemany(
+    await cursor.executemany(
         "INSERT INTO bulkinsert (id, name, age, height) "
         "VALUES (%s,%s,%s,%s);", data)
     expected = bytearray(b"INSERT INTO bulkinsert (id, name, age, height) "
                          b"VALUES (0,'bob',21,123),(1,'jim',56,45)")
     assert cursor._last_executed == expected
-    yield from cursor.execute('commit')
-    yield from assert_records(data)
+    await cursor.execute('commit')
+    await assert_records(data)

--- a/tests/test_load_local.py
+++ b/tests/test_load_local.py
@@ -1,4 +1,3 @@
-import asyncio
 import builtins
 import os
 from unittest.mock import patch, MagicMock
@@ -14,7 +13,7 @@ def table_local_file(connection, loop):
         c = await conn.cursor()
         await c.execute("DROP TABLE IF EXISTS test_load_local;")
         await c.execute("CREATE TABLE test_load_local "
-                             "(a INTEGER, b INTEGER)")
+                        "(a INTEGER, b INTEGER)")
         await c.close()
 
     async def drop_table(conn):
@@ -48,8 +47,8 @@ async def test_error_on_file_read(cursor, table_local_file):
 
         with pytest.raises(OperationalError):
             await cursor.execute("LOAD DATA LOCAL INFILE 'some.txt'"
-                                      " INTO TABLE test_load_local fields "
-                                      "terminated by ','")
+                                 " INTO TABLE test_load_local fields "
+                                 "terminated by ','")
 
 
 @pytest.mark.run_loop

--- a/tests/test_nextset.py
+++ b/tests/test_nextset.py
@@ -2,70 +2,70 @@ import pytest
 
 
 @pytest.mark.run_loop
-def test_nextset(cursor):
-    yield from cursor.execute("SELECT 1; SELECT 2;")
-    r = yield from cursor.fetchall()
+async def test_nextset(cursor):
+    await cursor.execute("SELECT 1; SELECT 2;")
+    r = await cursor.fetchall()
     assert [(1,)] == list(r)
 
-    r = yield from cursor.nextset()
+    r = await cursor.nextset()
     assert r
 
-    r = yield from cursor.fetchall()
+    r = await cursor.fetchall()
     assert [(2,)] == list(r)
-    res = yield from cursor.nextset()
+    res = await cursor.nextset()
     assert res is None
 
 
 @pytest.mark.run_loop
-def test_skip_nextset(cursor):
-    yield from cursor.execute("SELECT 1; SELECT 2;")
-    r = yield from cursor.fetchall()
+async def test_skip_nextset(cursor):
+    await cursor.execute("SELECT 1; SELECT 2;")
+    r = await cursor.fetchall()
     assert [(1,)] == list(r)
 
-    yield from cursor.execute("SELECT 42")
-    r = yield from cursor.fetchall()
+    await cursor.execute("SELECT 42")
+    r = await cursor.fetchall()
     assert [(42,)] == list(r)
 
 
 @pytest.mark.run_loop
-def test_ok_and_next(cursor):
-    yield from cursor.execute("SELECT 1; commit; SELECT 2;")
-    r = yield from cursor.fetchall()
+async def test_ok_and_next(cursor):
+    await cursor.execute("SELECT 1; commit; SELECT 2;")
+    r = await cursor.fetchall()
     assert [(1,)] == list(r)
 
-    res = yield from cursor.nextset()
+    res = await cursor.nextset()
     assert res
 
-    res = yield from cursor.nextset()
+    res = await cursor.nextset()
     assert res
 
-    r = yield from cursor.fetchall()
+    r = await cursor.fetchall()
     assert [(2,)] == list(r)
 
-    res = yield from cursor.nextset()
+    res = await cursor.nextset()
     assert res is None
 
 
 @pytest.mark.xfail
 @pytest.mark.run_loop
-def test_multi_cursorxx(connection):
-    cur1 = yield from connection.cursor()
-    cur2 = yield from connection.cursor()
+async def test_multi_cursorxx(connection):
+    cur1 = await connection.cursor()
+    cur2 = await connection.cursor()
 
-    yield from cur1.execute("SELECT 1; SELECT 2;")
-    yield from cur2.execute("SELECT 42")
+    await cur1.execute("SELECT 1; SELECT 2;")
+    await cur2.execute("SELECT 42")
 
-    r1 = yield from cur1.fetchall()
-    r2 = yield from cur2.fetchall()
+    r1 = await cur1.fetchall()
+    r2 = await cur2.fetchall()
 
     assert [(1,)] == list(r1)
     assert [(42,)] == list(r2)
 
-    res = yield from cur1.nextset()
+    res = await cur1.nextset()
     assert res
 
     assert [(2,)] == list(r1)
-    res = yield from cur1.nextset()
+    res = await cur1.nextset()
     assert res is None
 
     # TODO: How about SSCursor and nextset?

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -6,8 +6,8 @@ from aiomysql.pool import Pool
 
 
 @pytest.mark.run_loop
-def test_create_pool(pool_creator):
-    pool = yield from pool_creator()
+async def test_create_pool(pool_creator):
+    pool = await pool_creator()
     assert isinstance(pool, Pool)
     assert 1 == pool.minsize
     assert 10 == pool.maxsize
@@ -17,8 +17,8 @@ def test_create_pool(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_create_pool2(pool_creator):
-    pool = yield from pool_creator(minsize=10, maxsize=20)
+async def test_create_pool2(pool_creator):
+    pool = await pool_creator(minsize=10, maxsize=20)
     assert isinstance(pool, Pool)
     assert 10 == pool.minsize
     assert 20 == pool.maxsize
@@ -27,23 +27,23 @@ def test_create_pool2(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_acquire(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_acquire(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     assert isinstance(conn, Connection)
     assert not conn.closed
-    cursor = yield from conn.cursor()
-    yield from cursor.execute('SELECT 1')
-    val = yield from cursor.fetchone()
-    yield from cursor.close()
+    cursor = await conn.cursor()
+    await cursor.execute('SELECT 1')
+    val = await cursor.fetchone()
+    await cursor.close()
     assert (1,) == val
     pool.release(conn)
 
 
 @pytest.mark.run_loop
-def test_release(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_release(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     assert 0 == pool.freesize
     assert {conn} == pool._used
     pool.release(conn)
@@ -52,34 +52,34 @@ def test_release(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_release_closed(pool_creator):
-    pool = yield from pool_creator(minsize=10, maxsize=10)
-    conn = yield from pool.acquire()
+async def test_release_closed(pool_creator):
+    pool = await pool_creator(minsize=10, maxsize=10)
+    conn = await pool.acquire()
     assert 9 == pool.freesize
-    yield from conn.ensure_closed()
+    await conn.ensure_closed()
     pool.release(conn)
     assert 9 == pool.freesize
     assert not pool._used
     assert 9 == pool.size
 
-    conn2 = yield from pool.acquire()
+    conn2 = await pool.acquire()
     assert 9 == pool.freesize
     assert 10 == pool.size
     pool.release(conn2)
 
 
 @pytest.mark.run_loop
-def test_bad_context_manager_usage(pool_creator):
-    pool = yield from pool_creator()
+async def test_bad_context_manager_usage(pool_creator):
+    pool = await pool_creator()
     with pytest.raises(RuntimeError):
         with pool:
             pass
 
 
 @pytest.mark.run_loop
-def test_context_manager(pool_creator):
-    pool = yield from pool_creator(minsize=10, maxsize=10)
-    with (yield from pool) as conn:
+async def test_context_manager(pool_creator):
+    pool = await pool_creator(minsize=10, maxsize=10)
+    with (await pool) as conn:
         assert isinstance(conn, Connection)
         assert 9 == pool.freesize
         assert {conn} == pool._used
@@ -87,31 +87,31 @@ def test_context_manager(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_clear(pool_creator):
-    pool = yield from pool_creator()
-    yield from pool.clear()
+async def test_clear(pool_creator):
+    pool = await pool_creator()
+    await pool.clear()
     assert 0 == pool.freesize
 
 
 @pytest.mark.run_loop
-def test_initial_empty(pool_creator):
-    pool = yield from pool_creator(minsize=0)
+async def test_initial_empty(pool_creator):
+    pool = await pool_creator(minsize=0)
     assert 10 == pool.maxsize
     assert 0 == pool.minsize
     assert 0 == pool.size
     assert 0 == pool.freesize
 
-    with (yield from pool):
+    with (await pool):
         assert 1 == pool.size
         assert 0 == pool.freesize
     assert 1 == pool.size
     assert 1 == pool.freesize
 
-    conn1 = yield from pool.acquire()
+    conn1 = await pool.acquire()
     assert 1 == pool.size
     assert 0 == pool.freesize
 
-    conn2 = yield from pool.acquire()
+    conn2 = await pool.acquire()
     assert 2 == pool.size
     assert 0 == pool.freesize
 
@@ -125,8 +125,8 @@ def test_initial_empty(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_parallel_tasks(pool_creator, loop):
-    pool = yield from pool_creator(minsize=0, maxsize=2)
+async def test_parallel_tasks(pool_creator, loop):
+    pool = await pool_creator(minsize=0, maxsize=2)
     assert 2 == pool.maxsize
     assert 0 == pool.minsize
     assert 0 == pool.size
@@ -135,7 +135,7 @@ def test_parallel_tasks(pool_creator, loop):
     fut1 = pool.acquire()
     fut2 = pool.acquire()
 
-    conn1, conn2 = yield from asyncio.gather(fut1, fut2, loop=loop)
+    conn1, conn2 = await asyncio.gather(fut1, fut2, loop=loop)
     assert 2 == pool.size
     assert 0 == pool.freesize
     assert {conn1, conn2} == pool._used
@@ -151,20 +151,20 @@ def test_parallel_tasks(pool_creator, loop):
     assert not conn1.closed
     assert not conn2.closed
 
-    conn3 = yield from pool.acquire()
+    conn3 = await pool.acquire()
     assert conn3 is conn1
     pool.release(conn3)
 
 
 @pytest.mark.run_loop
-def test_parallel_tasks_more(pool_creator, loop):
-    pool = yield from pool_creator(minsize=0, maxsize=3)
+async def test_parallel_tasks_more(pool_creator, loop):
+    pool = await pool_creator(minsize=0, maxsize=3)
 
     fut1 = pool.acquire()
     fut2 = pool.acquire()
     fut3 = pool.acquire()
 
-    conn1, conn2, conn3 = yield from asyncio.gather(fut1, fut2, fut3,
+    conn1, conn2, conn3 = await asyncio.gather(fut1, fut2, fut3,
                                                     loop=loop)
     assert 3 == pool.size
     assert 0 == pool.freesize
@@ -190,27 +190,27 @@ def test_parallel_tasks_more(pool_creator, loop):
     assert not conn2.closed
     assert not conn3.closed
 
-    conn4 = yield from pool.acquire()
+    conn4 = await pool.acquire()
     assert conn4 is conn1
     pool.release(conn4)
 
 
 @pytest.mark.run_loop
-def test_default_event_loop(pool_creator, loop):
+async def test_default_event_loop(pool_creator, loop):
     asyncio.set_event_loop(loop)
-    pool = yield from pool_creator(loop=None)
+    pool = await pool_creator(loop=None)
     assert pool._loop is loop
 
 
 @pytest.mark.run_loop
-def test_release_with_invalid_status(pool_creator):
-    pool = yield from pool_creator(minsize=10, maxsize=10)
-    conn = yield from pool.acquire()
+async def test_release_with_invalid_status(pool_creator):
+    pool = await pool_creator(minsize=10, maxsize=10)
+    conn = await pool.acquire()
     assert 9 == pool.freesize
     assert {conn} == pool._used
-    cur = yield from conn.cursor()
-    yield from cur.execute('BEGIN')
-    yield from cur.close()
+    cur = await conn.cursor()
+    await cur.execute('BEGIN')
+    await cur.close()
 
     pool.release(conn)
     assert 9 == pool.freesize
@@ -219,29 +219,29 @@ def test_release_with_invalid_status(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_release_with_invalid_status_wait_release(pool_creator):
-    pool = yield from pool_creator(minsize=10, maxsize=10)
-    conn = yield from pool.acquire()
+async def test_release_with_invalid_status_wait_release(pool_creator):
+    pool = await pool_creator(minsize=10, maxsize=10)
+    conn = await pool.acquire()
     assert 9 == pool.freesize
     assert {conn} == pool._used
-    cur = yield from conn.cursor()
-    yield from cur.execute('BEGIN')
-    yield from cur.close()
+    cur = await conn.cursor()
+    await cur.execute('BEGIN')
+    await cur.close()
 
-    yield from pool.release(conn)
+    await pool.release(conn)
     assert 9 == pool.freesize
     assert not pool._used
     assert conn.closed
 
 
 @pytest.mark.run_loop
-def test__fill_free(pool_creator, loop):
-    pool = yield from pool_creator(minsize=1)
-    with (yield from pool):
+async def test__fill_free(pool_creator, loop):
+    pool = await pool_creator(minsize=1)
+    with (await pool):
         assert 0 == pool.freesize
         assert 1 == pool.size
 
-        conn = yield from asyncio.wait_for(pool.acquire(),
+        conn = await asyncio.wait_for(pool.acquire(),
                                            timeout=0.5,
                                            loop=loop)
         assert 0 == pool.freesize
@@ -254,11 +254,11 @@ def test__fill_free(pool_creator, loop):
 
 
 @pytest.mark.run_loop
-def test_connect_from_acquire(pool_creator):
-    pool = yield from pool_creator(minsize=0)
+async def test_connect_from_acquire(pool_creator):
+    pool = await pool_creator(minsize=0)
     assert 0 == pool.freesize
     assert 0 == pool.size
-    with (yield from pool):
+    with (await pool):
         assert 1 == pool.size
         assert 0 == pool.freesize
     assert 1 == pool.size
@@ -266,10 +266,10 @@ def test_connect_from_acquire(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_concurrency(pool_creator):
-    pool = yield from pool_creator(minsize=2, maxsize=4)
-    c1 = yield from pool.acquire()
-    c2 = yield from pool.acquire()
+async def test_concurrency(pool_creator):
+    pool = await pool_creator(minsize=2, maxsize=4)
+    c1 = await pool.acquire()
+    c2 = await pool.acquire()
     assert 0 == pool.freesize
     assert 2 == pool.size
     pool.release(c1)
@@ -277,17 +277,17 @@ def test_concurrency(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_invalid_minsize_and_maxsize(pool_creator):
+async def test_invalid_minsize_and_maxsize(pool_creator):
     with pytest.raises(ValueError):
-        yield from pool_creator(minsize=-1)
+        await pool_creator(minsize=-1)
 
     with pytest.raises(ValueError):
-        yield from pool_creator(minsize=5, maxsize=2)
+        await pool_creator(minsize=5, maxsize=2)
 
 
 @pytest.mark.run_loop
-def test_true_parallel_tasks(pool_creator, loop):
-    pool = yield from pool_creator(minsize=0, maxsize=1)
+async def test_true_parallel_tasks(pool_creator, loop):
+    pool = await pool_creator(minsize=0, maxsize=1)
     assert 1 == pool.maxsize
     assert 0 == pool.minsize
     assert 0 == pool.size
@@ -296,58 +296,55 @@ def test_true_parallel_tasks(pool_creator, loop):
     maxsize = 0
     minfreesize = 100
 
-    @asyncio.coroutine
-    def inner():
+    async def inner():
         nonlocal maxsize, minfreesize
         maxsize = max(maxsize, pool.size)
         minfreesize = min(minfreesize, pool.freesize)
-        conn = yield from pool.acquire()
+        conn = await pool.acquire()
         maxsize = max(maxsize, pool.size)
         minfreesize = min(minfreesize, pool.freesize)
-        yield from asyncio.sleep(0.01, loop=loop)
+        await asyncio.sleep(0.01, loop=loop)
         pool.release(conn)
         maxsize = max(maxsize, pool.size)
         minfreesize = min(minfreesize, pool.freesize)
 
-    yield from asyncio.gather(inner(), inner(), loop=loop)
+    await asyncio.gather(inner(), inner(), loop=loop)
 
     assert 1 == maxsize
     assert 0 == minfreesize
 
 
 @pytest.mark.run_loop
-def test_cannot_acquire_after_closing(pool_creator):
-    pool = yield from pool_creator()
+async def test_cannot_acquire_after_closing(pool_creator):
+    pool = await pool_creator()
     pool.close()
 
     with pytest.raises(RuntimeError):
-        yield from pool.acquire()
+        await pool.acquire()
 
 
 @pytest.mark.run_loop
-def test_wait_closed(pool_creator, loop):
-    pool = yield from pool_creator(minsize=10, maxsize=10)
+async def test_wait_closed(pool_creator, loop):
+    pool = await pool_creator(minsize=10, maxsize=10)
 
-    c1 = yield from pool.acquire()
-    c2 = yield from pool.acquire()
+    c1 = await pool.acquire()
+    c2 = await pool.acquire()
     assert 10 == pool.size
     assert 8 == pool.freesize
 
     ops = []
 
-    @asyncio.coroutine
-    def do_release(conn):
-        yield from asyncio.sleep(0, loop=loop)
+    async def do_release(conn):
+        await asyncio.sleep(0, loop=loop)
         pool.release(conn)
         ops.append('release')
 
-    @asyncio.coroutine
-    def wait_closed():
-        yield from pool.wait_closed()
+    async def wait_closed():
+        await pool.wait_closed()
         ops.append('wait_closed')
 
     pool.close()
-    yield from asyncio.gather(wait_closed(),
+    await asyncio.gather(wait_closed(),
                               do_release(c1),
                               do_release(c2),
                               loop=loop)
@@ -356,27 +353,27 @@ def test_wait_closed(pool_creator, loop):
 
 
 @pytest.mark.run_loop
-def test_echo(pool_creator):
-    pool = yield from pool_creator(echo=True)
+async def test_echo(pool_creator):
+    pool = await pool_creator(echo=True)
     assert pool.echo
 
-    with (yield from pool) as conn:
+    with (await pool) as conn:
         assert conn.echo
 
 
 @pytest.mark.run_loop
-def test_terminate_with_acquired_connections(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_terminate_with_acquired_connections(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     pool.terminate()
-    yield from pool.wait_closed()
+    await pool.wait_closed()
     assert conn.closed
 
 
 @pytest.mark.run_loop
-def test_release_closed_connection(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_release_closed_connection(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     conn.close()
 
     pool.release(conn)
@@ -384,137 +381,135 @@ def test_release_closed_connection(pool_creator):
 
 
 @pytest.mark.run_loop
-def test_wait_closing_on_not_closed(pool_creator):
-    pool = yield from pool_creator()
+async def test_wait_closing_on_not_closed(pool_creator):
+    pool = await pool_creator()
 
     with pytest.raises(RuntimeError):
-        yield from pool.wait_closed()
+        await pool.wait_closed()
     pool.close()
 
 
 @pytest.mark.run_loop
-def test_release_terminated_pool(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_release_terminated_pool(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     pool.terminate()
-    yield from pool.wait_closed()
+    await pool.wait_closed()
 
     pool.release(conn)
     pool.close()
 
 
 @pytest.mark.run_loop
-def test_release_terminated_pool_wait_release(pool_creator):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_release_terminated_pool_wait_release(pool_creator):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     pool.terminate()
-    yield from pool.wait_closed()
+    await pool.wait_closed()
 
-    yield from pool.release(conn)
+    await pool.release(conn)
     pool.close()
 
 
 @pytest.mark.run_loop
-def test_close_with_acquired_connections(pool_creator, loop):
-    pool = yield from pool_creator()
-    conn = yield from pool.acquire()
+async def test_close_with_acquired_connections(pool_creator, loop):
+    pool = await pool_creator()
+    conn = await pool.acquire()
     pool.close()
 
     with pytest.raises(asyncio.TimeoutError):
-        yield from asyncio.wait_for(pool.wait_closed(), 0.1, loop=loop)
+        await asyncio.wait_for(pool.wait_closed(), 0.1, loop=loop)
     pool.release(conn)
 
 
-@asyncio.coroutine
-def _set_global_conn_timeout(conn, t):
+async def _set_global_conn_timeout(conn, t):
     # create separate connection to setup global connection timeouts
     # https://dev.mysql.com/doc/refman/5.1/en/server-system-variables
     # .html#sysvar_interactive_timeout
-    cur = yield from conn.cursor()
-    yield from cur.execute('SET GLOBAL wait_timeout=%s;', t)
-    yield from cur.execute('SET GLOBAL interactive_timeout=%s;', t)
-    yield from cur.close()
+    cur = await conn.cursor()
+    await cur.execute('SET GLOBAL wait_timeout=%s;', t)
+    await cur.execute('SET GLOBAL interactive_timeout=%s;', t)
+    await cur.close()
 
 
 @pytest.mark.run_loop
-def test_drop_connection_if_timedout(pool_creator, connection_creator, loop):
-    conn = yield from connection_creator()
-    yield from _set_global_conn_timeout(conn, 2)
-    yield from conn.ensure_closed()
+async def test_drop_connection_if_timedout(pool_creator, connection_creator, loop):
+    conn = await connection_creator()
+    await _set_global_conn_timeout(conn, 2)
+    await conn.ensure_closed()
     try:
-        pool = yield from pool_creator(minsize=3, maxsize=3)
+        pool = await pool_creator(minsize=3, maxsize=3)
         # sleep, more then connection timeout
-        yield from asyncio.sleep(3, loop=loop)
-        conn = yield from pool.acquire()
-        cur = yield from conn.cursor()
+        await asyncio.sleep(3, loop=loop)
+        conn = await pool.acquire()
+        cur = await conn.cursor()
         # query should not throw exception OperationalError
-        yield from cur.execute('SELECT 1;')
+        await cur.execute('SELECT 1;')
         pool.release(conn)
         pool.close()
-        yield from pool.wait_closed()
+        await pool.wait_closed()
     finally:
         # setup default timeouts
-        conn = yield from connection_creator()
-        yield from _set_global_conn_timeout(conn, 28800)
-        yield from conn.ensure_closed()
+        conn = await connection_creator()
+        await _set_global_conn_timeout(conn, 28800)
+        await conn.ensure_closed()
 
 
 @pytest.mark.skip(reason='Not implemented')
 @pytest.mark.run_loop
-def test_create_pool_with_timeout(pool_creator):
-    pool = yield from pool_creator(minsize=3, maxsize=3)
+async def test_create_pool_with_timeout(pool_creator):
+    pool = await pool_creator(minsize=3, maxsize=3)
     timeout = 0.1
     assert timeout == pool.timeout
-    conn = yield from pool.acquire()
+    conn = await pool.acquire()
     assert timeout == conn.timeout
     pool.release(conn)
 
 
 @pytest.mark.run_loop
-def test_cancelled_connection(pool_creator, loop):
-    pool = yield from pool_creator(minsize=0, maxsize=1)
+async def test_cancelled_connection(pool_creator, loop):
+    pool = await pool_creator(minsize=0, maxsize=1)
 
     try:
-        with (yield from pool) as conn:
-            curs = yield from conn.cursor()
+        with (await pool) as conn:
+            curs = await conn.cursor()
             # Cancel a cursor in the middle of execution, before it
             # could read even the first packet (SLEEP assures the
             # timings)
             task = loop.create_task(curs.execute(
                 "SELECT 1 as id, SLEEP(0.1) as xxx"))
-            yield from asyncio.sleep(0.05, loop=loop)
+            await asyncio.sleep(0.05, loop=loop)
             task.cancel()
-            yield from task
+            await task
     except asyncio.CancelledError:
         pass
 
-    with (yield from pool) as conn:
-        cur2 = yield from conn.cursor()
-        res = yield from cur2.execute("SELECT 2 as value, 0 as xxx")
+    with (await pool) as conn:
+        cur2 = await conn.cursor()
+        res = await cur2.execute("SELECT 2 as value, 0 as xxx")
         names = [x[0] for x in cur2.description]
         # If we receive ["id", "xxx"] - we corrupted the connection
         assert names == ["value", "xxx"]
-        res = yield from cur2.fetchall()
+        res = await cur2.fetchall()
         # If we receive [(1, 0)] - we retrieved old cursor's values
         assert list(res) == [(2, 0)]
 
 
-@asyncio.coroutine
-def test_pool_with_connection_recycling(pool_creator, loop):
-    pool = yield from pool_creator(minsize=1,
+async def test_pool_with_connection_recycling(pool_creator, loop):
+    pool = await pool_creator(minsize=1,
                                    maxsize=1,
                                    pool_recycle=3)
-    with (yield from pool) as conn:
-        cur = yield from conn.cursor()
-        yield from cur.execute('SELECT 1;')
-        val = yield from cur.fetchone()
+    with (await pool) as conn:
+        cur = await conn.cursor()
+        await cur.execute('SELECT 1;')
+        val = await cur.fetchone()
         assert (1,) == val
 
-    yield from asyncio.sleep(5, loop=loop)
+    await asyncio.sleep(5, loop=loop)
 
     assert 1 == pool.freesize
-    with (yield from pool) as conn:
-        cur = yield from conn.cursor()
-        yield from cur.execute('SELECT 1;')
-        val = yield from cur.fetchone()
+    with (await pool) as conn:
+        cur = await conn.cursor()
+        await cur.execute('SELECT 1;')
+        val = await cur.fetchone()
         assert (1,) == val

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -165,7 +165,7 @@ async def test_parallel_tasks_more(pool_creator, loop):
     fut3 = pool.acquire()
 
     conn1, conn2, conn3 = await asyncio.gather(fut1, fut2, fut3,
-                                                    loop=loop)
+                                               loop=loop)
     assert 3 == pool.size
     assert 0 == pool.freesize
     assert {conn1, conn2, conn3} == pool._used
@@ -242,8 +242,7 @@ async def test__fill_free(pool_creator, loop):
         assert 1 == pool.size
 
         conn = await asyncio.wait_for(pool.acquire(),
-                                           timeout=0.5,
-                                           loop=loop)
+                                      timeout=0.5, loop=loop)
         assert 0 == pool.freesize
         assert 2 == pool.size
         pool.release(conn)
@@ -344,10 +343,8 @@ async def test_wait_closed(pool_creator, loop):
         ops.append('wait_closed')
 
     pool.close()
-    await asyncio.gather(wait_closed(),
-                              do_release(c1),
-                              do_release(c2),
-                              loop=loop)
+    await asyncio.gather(wait_closed(), do_release(c1), do_release(c2),
+                         loop=loop)
     assert ['release', 'release', 'wait_closed'] == ops
     assert 0 == pool.freesize
 
@@ -433,7 +430,8 @@ async def _set_global_conn_timeout(conn, t):
 
 
 @pytest.mark.run_loop
-async def test_drop_connection_if_timedout(pool_creator, connection_creator, loop):
+async def test_drop_connection_if_timedout(pool_creator,
+                                           connection_creator, loop):
     conn = await connection_creator()
     await _set_global_conn_timeout(conn, 2)
     await conn.ensure_closed()
@@ -496,9 +494,7 @@ async def test_cancelled_connection(pool_creator, loop):
 
 
 async def test_pool_with_connection_recycling(pool_creator, loop):
-    pool = await pool_creator(minsize=1,
-                                   maxsize=1,
-                                   pool_recycle=3)
+    pool = await pool_creator(minsize=1, maxsize=1, pool_recycle=3)
     async with pool.get() as conn:
         cur = await conn.cursor()
         await cur.execute('SELECT 1;')


### PR DESCRIPTION
#281 Point 2 Replace yield from with await.

Well this resulted in a nastier diff than I expected :D.

Have replaced the majority of the `yield from` with `await` and `@asyncio.coroutine` with `async`

This is more a placeholder for when you want to purge the yield from. Its not 100% finished but if you fancy reading through it, by all means :)