### PR TITLE
ability to execute precompiled sqlalchemy queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changes
 -------
 
+0.0.16 (2018-05-21)
+^^^^^^^^^^^^^^^^^^^
+
+* Added ability to execute precompiled sqlalchemy queries
+
+
 0.0.15 (2018-05-20)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/aiomysql/__init__.py
+++ b/aiomysql/__init__.py
@@ -33,7 +33,7 @@ from .connection import Connection, connect
 from .cursors import Cursor, SSCursor, DictCursor, SSDictCursor
 from .pool import create_pool, Pool
 
-__version__ = '0.0.15'
+__version__ = '0.0.16'
 
 __all__ = [
 


### PR DESCRIPTION
Ability to execute pre-compiled queries removes ~30% sqlalchemy compilation overhead when the query is run repeatedly.

@jettify can you please review the changes? If the idea is ok, i will add tests