### PR TITLE
Apply more conservative version pinning

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ ipython==6.4.0
 pytest==3.6.1
 pytest-cov==2.5.1
 pytest-sugar==0.9.1
-PyMySQL>=0.7.5
+PyMySQL>=0.7.5,<0.9
 docker==3.3.0
 sphinx==1.7.5
 sphinxcontrib-asyncio==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['PyMySQL>=0.7.5']
+install_requires = ['PyMySQL>=0.7.5,<0.9']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
This should repair #302 until a better fix lands to support PyMySQL 0.9.0