### PR TITLE
MySQL 8 Compatibility and SHA256 authentication plugin support

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -795,38 +795,44 @@ class Connection:
                                        "for auth method %r", auth_plugin)
 
     async def _process_auth(self, plugin_name, auth_packet):
+        # These auth plugins do their own packet handling
         if plugin_name == b"caching_sha2_password":
-            return self.caching_sha2_password_auth(auth_packet)
+            await self.caching_sha2_password_auth(auth_packet)
         elif plugin_name == b"sha256_password":
-            return self.sha256_password_auth(auth_packet)
-        elif plugin_name == b"mysql_native_password":
-            # https://dev.mysql.com/doc/internals/en/
-            # secure-password-authentication.html#packet-Authentication::
-            # Native41
-            data = _auth.scramble_native_password(
-                self._password.encode('latin1'),
-                auth_packet.read_all())
-        elif plugin_name == b"mysql_old_password":
-            # https://dev.mysql.com/doc/internals/en/
-            # old-password-authentication.html
-            data = _auth.scramble_old_password(self._password.encode('latin1'),
-                                               auth_packet.read_all()) + b'\0'
-        elif plugin_name == b"mysql_clear_password":
-            # https://dev.mysql.com/doc/internals/en/
-            # clear-text-authentication.html
-            data = self._password.encode('latin1') + b'\0'
+            await self.sha256_password_auth(auth_packet)
         else:
-            raise OperationalError(
-                2059, "Authentication plugin '%s' not configured" % plugin_name
-            )
 
-        self.write_packet(data)
-        pkt = await self._read_packet()
-        pkt.check_error()
+            if plugin_name == b"mysql_native_password":
+                # https://dev.mysql.com/doc/internals/en/
+                # secure-password-authentication.html#packet-Authentication::
+                # Native41
+                data = _auth.scramble_native_password(
+                    self._password.encode('latin1'),
+                    auth_packet.read_all())
+            elif plugin_name == b"mysql_old_password":
+                # https://dev.mysql.com/doc/internals/en/
+                # old-password-authentication.html
+                data = _auth.scramble_old_password(
+                    self._password.encode('latin1'),
+                    auth_packet.read_all()
+                ) + b'\0'
+            elif plugin_name == b"mysql_clear_password":
+                # https://dev.mysql.com/doc/internals/en/
+                # clear-text-authentication.html
+                data = self._password.encode('latin1') + b'\0'
+            else:
+                raise OperationalError(
+                    2059, "Authentication plugin '{0}'"
+                          " not configured".format(plugin_name)
+                )
 
-        self._auth_plugin_used = plugin_name
+            self.write_packet(data)
+            pkt = await self._read_packet()
+            pkt.check_error()
 
-        return pkt
+            self._auth_plugin_used = plugin_name
+
+            return pkt
 
     async def caching_sha2_password_auth(self, pkt):
         # No password fast path

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -798,10 +798,10 @@ class Connection:
         # These auth plugins do their own packet handling
         if plugin_name == b"caching_sha2_password":
             await self.caching_sha2_password_auth(auth_packet)
-            self._auth_plugin_used = plugin_name
+            self._auth_plugin_used = plugin_name.decode()
         elif plugin_name == b"sha256_password":
             await self.sha256_password_auth(auth_packet)
-            self._auth_plugin_used = plugin_name
+            self._auth_plugin_used = plugin_name.decode()
         else:
 
             if plugin_name == b"mysql_native_password":
@@ -832,7 +832,7 @@ class Connection:
             pkt = await self._read_packet()
             pkt.check_error()
 
-            self._auth_plugin_used = plugin_name
+            self._auth_plugin_used = plugin_name.decode()
 
             return pkt
 

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -798,8 +798,10 @@ class Connection:
         # These auth plugins do their own packet handling
         if plugin_name == b"caching_sha2_password":
             await self.caching_sha2_password_auth(auth_packet)
+            self._auth_plugin_used = plugin_name
         elif plugin_name == b"sha256_password":
             await self.sha256_password_auth(auth_packet)
+            self._auth_plugin_used = plugin_name
         else:
 
             if plugin_name == b"mysql_native_password":

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -47,7 +47,8 @@ Example::
             client_flag=0, cursorclass=Cursor, init_command=None,
             connect_timeout=None, read_default_group=None,
             no_delay=False, autocommit=False, echo=False,
-            ssl=None, auth_plugin='', program_name='', loop=None)
+            ssl=None, auth_plugin='', program_name='',
+            server_public_key=None, loop=None)
 
     A :ref:`coroutine <coroutine>` that connects to MySQL.
 
@@ -89,6 +90,7 @@ Example::
         (default: Server Default)
     :param program_name: Program name string to provide when
         handshaking with MySQL. (default: sys.argv[0])
+    :param server_public_key: SHA256 authenticaiton plugin public key value.
     :param loop: asyncio event loop instance or ``None`` for default one.
     :returns: :class:`Connection` instance.
 

--- a/examples/example_ssl.py
+++ b/examples/example_ssl.py
@@ -1,0 +1,38 @@
+import asyncio
+import ssl
+import aiomysql
+
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+ctx.check_hostname = False
+ctx.load_verify_locations(cafile='../tests/ssl_resources/ssl/ca.pem')
+
+
+async def main():
+    async with aiomysql.create_pool(
+            host='localhost', port=3306, user='root',
+            password='rootpw', ssl=ctx,
+            auth_plugin='mysql_clear_password') as pool:
+
+        async with pool.get() as conn:
+            async with conn.cursor() as cur:
+                # Run simple command
+                await cur.execute("SHOW DATABASES;")
+                value = await cur.fetchall()
+
+                values = [item[0] for item in value]
+                # Spot check the answers, we should at least have mysql
+                # and information_schema
+                assert 'mysql' in values, \
+                    'Could not find the "mysql" table'
+                assert 'information_schema' in values, \
+                    'Could not find the "mysql" table'
+
+                # Check TLS variables
+                await cur.execute("SHOW STATUS LIKE 'Ssl_version%';")
+                value = await cur.fetchone()
+
+                # The context has TLS
+                assert value[1].startswith('TLS'), \
+                    'Not connected to the database with TLS'
+
+asyncio.get_event_loop().run_until_complete(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,15 +35,15 @@ def pytest_generate_tests(metafunc):
         loop_type = ['asyncio', 'uvloop'] if uvloop else ['asyncio']
         metafunc.parametrize("loop_type", loop_type)
 
-    # if 'mysql_tag' in metafunc.fixturenames:
-    #     tags = set(metafunc.config.option.mysql_tag)
-    #     if not tags:
-    #         tags = ['5.7']
-    #     elif 'all' in tags:
-    #         tags = ['5.6', '5.7', '8.0']
-    #     else:
-    #         tags = list(tags)
-    #     metafunc.parametrize("mysql_tag", tags, scope='session')
+    if 'mysql_tag' in metafunc.fixturenames:
+        # tags = set(metafunc.config.option.mysql_tag)
+        # if not tags:
+        #     tags = ['5.7']
+        # elif 'all' in tags:
+        #     tags = ['5.6', '5.7', '8.0']
+        # else:
+        #     tags = list(tags)
+        metafunc.parametrize("mysql_tag", ['5.6', '8.0'], scope='session')
 
 
 # This is here unless someone fixes the generate_tests bit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,14 +36,14 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("loop_type", loop_type)
 
     if 'mysql_tag' in metafunc.fixturenames:
-        # tags = set(metafunc.config.option.mysql_tag)
-        # if not tags:
-        #     tags = ['5.7']
-        # elif 'all' in tags:
-        #     tags = ['5.6', '5.7', '8.0']
-        # else:
-        #     tags = list(tags)
-        metafunc.parametrize("mysql_tag", ['5.6', '8.0'], scope='session')
+        tags = set(metafunc.config.option.mysql_tag)
+        if not tags:
+            tags = ['5.6', '8.0']
+        elif 'all' in tags:
+            tags = ['5.6', '5.7', '8.0']
+        else:
+            tags = list(tags)
+        metafunc.parametrize("mysql_tag", tags, scope='session')
 
 
 # This is here unless someone fixes the generate_tests bit
@@ -288,7 +288,7 @@ def mysql_server(unused_port, docker, session_id, mysql_tag, request):
                     assert result['have_ssl'] == "YES", \
                         "SSL Not Enabled on docker'd MySQL"
 
-                    cursor.execute("SHOW STATUS LIKE '%Ssl_version%'")
+                    cursor.execute("SHOW STATUS LIKE 'Ssl_version%'")
 
                     result = cursor.fetchone()
                     # As we connected with TLS, it should start with that :D

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,8 @@ def ensure_mysql_verison(request, mysql_tag):
 
 @pytest.fixture(scope='session')
 def mysql_server(unused_port, docker, session_id, mysql_tag, request):
+    print('\nSTARTUP CONTAINER - {0}\n'.format(mysql_tag))
+
     if not request.config.option.no_pull:
         docker.pull('mysql:{}'.format(mysql_tag))
 
@@ -342,5 +344,6 @@ def mysql_server(unused_port, docker, session_id, mysql_tag, request):
 
         yield container
     finally:
+        print('\nTEARDOWN CONTAINER - {0}\n'.format(mysql_tag))
         docker.kill(container=container['Id'])
         docker.remove_container(container['Id'])

--- a/tests/test_sha_connection.py
+++ b/tests/test_sha_connection.py
@@ -4,22 +4,78 @@ from aiomysql import create_pool
 import pytest
 
 
+# You could parameterise these tests with this, but then pytest
+# does some funky stuff and spins up and tears down containers
+# per function call.  Remember it would be
+# mysql_versions * event_loops * 4 auth tests ~= 3*2*4 ~= 24 tests
+
+# As the MySQL daemon restarts at least 3 times in the container
+# before it becomes stable, there's a sleep(10) so that's
+# around a 4min wait time.
+
+# @pytest.mark.parametrize("user,password,plugin", [
+#     ("nopass_sha256", None, 'sha256_password'),
+#     ("user_sha256", 'pass_sha256', 'sha256_password'),
+#     ("nopass_caching_sha2", None, 'caching_sha2_password'),
+#     ("user_caching_sha2", 'pass_caching_sha2', 'caching_sha2_password'),
+# ])
+
+
 @pytest.mark.mysql_verison('8.0')
 @pytest.mark.run_loop
-@pytest.mark.parametrize("user,password,plugin", [
-    ("nopass_sha256", None, 'sha256_password'),
-    ("user_sha256", 'pass_sha256', 'sha256_password'),
-    ("nopass_caching_sha2", None, 'caching_sha2_password'),
-    ("user_caching_sha2", 'pass_caching_sha2', 'caching_sha2_password'),
-])
-async def test_sha(mysql_server, loop, user, password, plugin):
+async def test_sha256_nopw(mysql_server, loop):
     connection_data = copy.copy(mysql_server['conn_params'])
-    connection_data['user'] = user
-    connection_data['password'] = password
+    connection_data['user'] = 'nopass_sha256'
+    connection_data['password'] = None
 
     async with create_pool(**connection_data,
                            loop=loop) as pool:
         async with pool.get() as conn:
             # User doesnt have any permissions to look at DBs
             # But as 8.0 will default to caching_sha2_password
-            assert conn._auth_plugin_used == plugin
+            assert conn._auth_plugin_used == 'sha256_password'
+
+
+@pytest.mark.mysql_verison('8.0')
+@pytest.mark.run_loop
+async def test_sha256_pw(mysql_server, loop):
+    connection_data = copy.copy(mysql_server['conn_params'])
+    connection_data['user'] = 'user_sha256'
+    connection_data['password'] = 'pass_sha256'
+
+    async with create_pool(**connection_data,
+                           loop=loop) as pool:
+        async with pool.get() as conn:
+            # User doesnt have any permissions to look at DBs
+            # But as 8.0 will default to caching_sha2_password
+            assert conn._auth_plugin_used == 'sha256_password'
+
+
+@pytest.mark.mysql_verison('8.0')
+@pytest.mark.run_loop
+async def test_cached_sha256_nopw(mysql_server, loop):
+    connection_data = copy.copy(mysql_server['conn_params'])
+    connection_data['user'] = 'nopass_caching_sha2'
+    connection_data['password'] = None
+
+    async with create_pool(**connection_data,
+                           loop=loop) as pool:
+        async with pool.get() as conn:
+            # User doesnt have any permissions to look at DBs
+            # But as 8.0 will default to caching_sha2_password
+            assert conn._auth_plugin_used == 'caching_sha2_password'
+
+
+@pytest.mark.mysql_verison('8.0')
+@pytest.mark.run_loop
+async def test_cached_sha256_pw(mysql_server, loop):
+    connection_data = copy.copy(mysql_server['conn_params'])
+    connection_data['user'] = 'user_caching_sha2'
+    connection_data['password'] = 'pass_caching_sha2'
+
+    async with create_pool(**connection_data,
+                           loop=loop) as pool:
+        async with pool.get() as conn:
+            # User doesnt have any permissions to look at DBs
+            # But as 8.0 will default to caching_sha2_password
+            assert conn._auth_plugin_used == 'caching_sha2_password'

--- a/tests/test_sha_connection.py
+++ b/tests/test_sha_connection.py
@@ -1,0 +1,25 @@
+import copy
+from aiomysql import create_pool
+
+import pytest
+
+
+@pytest.mark.mysql_verison('8.0')
+@pytest.mark.run_loop
+@pytest.mark.parametrize("user,password,plugin", [
+    ("nopass_sha256", None, 'sha256_password'),
+    ("user_sha256", 'pass_sha256', 'sha256_password'),
+    ("nopass_caching_sha2", None, 'caching_sha2_password'),
+    ("user_caching_sha2", 'pass_caching_sha2', 'caching_sha2_password'),
+])
+async def test_sha(mysql_server, loop, user, password, plugin):
+    connection_data = copy.copy(mysql_server['conn_params'])
+    connection_data['user'] = user
+    connection_data['password'] = password
+
+    async with create_pool(**connection_data,
+                           loop=loop) as pool:
+        async with pool.get() as conn:
+            # User doesnt have any permissions to look at DBs
+            # But as 8.0 will default to caching_sha2_password
+            assert conn._auth_plugin_used == plugin

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -54,5 +54,5 @@ async def test_auth_plugin_renegotiation(mysql_server, loop):
                     'Server did not ask for native auth'
                 # Check we actually used the servers default plugin
                 assert conn._auth_plugin_used in (
-                    b'mysql_native_password', b'caching_sha2_password'), \
+                    'mysql_native_password', 'caching_sha2_password'), \
                     'Client did not renegotiate with server\'s default auth'

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -22,7 +22,7 @@ async def test_tls_connect(mysql_server, loop):
                     'Could not find the "mysql" table'
 
                 # Check TLS variables
-                await cur.execute("SHOW STATUS LIKE '%Ssl_version%';")
+                await cur.execute("SHOW STATUS LIKE 'Ssl_version%';")
                 value = await cur.fetchone()
 
                 # The context has TLS

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -44,9 +44,15 @@ async def test_auth_plugin_renegotiation(mysql_server, loop):
 
                 assert len(value), 'No databases found'
 
+                # Check we tried to use the cleartext plugin
                 assert conn._client_auth_plugin == 'mysql_clear_password', \
                     'Client did not try clear password auth'
-                assert conn._server_auth_plugin == 'mysql_native_password', \
+
+                # Check the server asked us to use MySQL's default plugin
+                assert conn._server_auth_plugin in (
+                    'mysql_native_password', 'caching_sha2_password'), \
                     'Server did not ask for native auth'
-                assert conn._auth_plugin_used == b'mysql_native_password', \
-                    'Client did not renegotiate with native auth'
+                # Check we actually used the servers default plugin
+                assert conn._auth_plugin_used in (
+                    b'mysql_native_password', b'caching_sha2_password'), \
+                    'Client did not renegotiate with server\'s default auth'


### PR DESCRIPTION
Fixes #302 
Fixes #297 

This PR contains the bulk of what PyMySQL 0.9.0 added which was support for MySQL 8+'s use of the `sha256_password` and `caching_sha2_password` authentication plugin.

I've also parameterised `mysql_tag` so it now tests connecting to MySQL 5.6 and 8.0 using SSL and as MySQL 8 defaults to the `caching_sha2_password`, that is tested by the current SSL unit tests.

I'm planning on creating a fixture that allows me to skip tests depending on the value of `mysql_tag` so I can target a few specific tests to 8.0 which should further test the `sha256_password` plugin.

---

@jettify I'm assuming you have no issue with me making a PR to move the other tests to using the MySQL server provided by the container, that way I think we can get rid of all the travis matrix except PYTHONASYNCIODEBUG.

In the top of `conftest.py` were checking for version 3.5 and optionally enabling uvloop, seeing as we've dropped less than 3.5.3 support that can go.