### PR TITLE
Import PyMySQL bugfix #649

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -589,6 +589,7 @@ class Connection:
         return self._writer.write(data)
 
     async def _read_query_result(self, unbuffered=False):
+        self._result = None
         if unbuffered:
             try:
                 result = MySQLResult(self)

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -184,6 +184,8 @@ class Cursor:
             return
         if not current_result.has_next:
             return
+        self._result = None
+        self._clear_result()
         await conn.next_result()
         await self._do_get_result()
         return True
@@ -449,8 +451,18 @@ class Cursor:
     async def _query(self, q):
         conn = self._get_db()
         self._last_executed = q
+        self._clear_result()
         await conn.query(q)
         await self._do_get_result()
+
+    def _clear_result(self):
+        self._rownumber = 0
+        self._result = None
+
+        self._rowcount = 0
+        self._description = None
+        self._lastrowid = None
+        self._rows = None
 
     async def _do_get_result(self):
         conn = self._get_db()

--- a/tests/test_nextset.py
+++ b/tests/test_nextset.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+from pymysql.err import ProgrammingError
 
 
 @pytest.mark.run_loop
@@ -25,6 +28,15 @@ async def test_skip_nextset(cursor):
     await cursor.execute("SELECT 42")
     r = await cursor.fetchall()
     assert [(42,)] == list(r)
+
+
+@pytest.mark.run_loop
+async def test_nextset_error(cursor):
+    await cursor.execute("SELECT 1; xyzzy;")
+
+    # nextset shouldn't hang on error
+    with pytest.raises(ProgrammingError):
+        await asyncio.wait_for(cursor.nextset(), 5)
 
 
 @pytest.mark.run_loop

--- a/tests/test_nextset.py
+++ b/tests/test_nextset.py
@@ -34,7 +34,7 @@ async def test_skip_nextset(cursor):
 async def test_nextset_error(cursor):
     await cursor.execute("SELECT 1; xyzzy;")
 
-    # nextset shouldn't hang on error
+    # nextset shouldn't hang on error, it should raise syntax error
     with pytest.raises(ProgrammingError):
         await asyncio.wait_for(cursor.nextset(), 5)
 


### PR DESCRIPTION
Fixes #251

Clears some cursor attributes which prevents nextset from hanging if the second query in the set is invalid.
