### PR TITLE
remove try connect in create engine

### DIFF
--- a/aiomysql/sa/engine.py
+++ b/aiomysql/sa/engine.py
@@ -48,11 +48,8 @@ async def _create_engine(minsize=1, maxsize=10, loop=None,
     pool = await aiomysql.create_pool(minsize=minsize, maxsize=maxsize,
                                       loop=loop,
                                       pool_recycle=pool_recycle, **kwargs)
-    conn = await pool.acquire()
-    try:
-        return Engine(dialect, pool, compiled_cache=compiled_cache, **kwargs)
-    finally:
-        pool.release(conn)
+
+    return Engine(dialect, pool, compiled_cache=compiled_cache, **kwargs)
 
 
 class Engine:


### PR DESCRIPTION
There is no need to try to connect remote when creating engine.

Just like origin Sqlalchemy, when creating engine that not check if the url is right.

By remove this, I can use create_engine with minsize=0, I will not fall down in starting a server but I can receive the error when I aquire a connection.