### PR TITLE
fix: support executemany

### DIFF
--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -63,7 +63,7 @@ class SAConnection:
         """
         coro = self._execute(query, *multiparams, **params)
         return _SAConnectionContextManager(coro)
-    
+
     def _base_params(self, query, dp, compiled, is_update):
         """
         handle params
@@ -105,7 +105,14 @@ class SAConnection:
             params = []
             is_update = isinstance(query, UpdateBase)
             for dp in dps:
-                params.append(self._base_params(query, dp, compiled, is_update))
+                params.append(
+                    self._base_params(
+                        query,
+                        dp,
+                        compiled,
+                        is_update,
+                    )
+                )
             await cursor.executemany(str(compiled), params)
         else:
             raise exc.ArgumentError(
@@ -144,7 +151,12 @@ class SAConnection:
                 compiled = query.compile(dialect=self._dialect)
 
             if not isinstance(query, DDLElement):
-                post_processed_params = self._base_params(query, dp, compiled, isinstance(query, UpdateBase))
+                post_processed_params = self._base_params(
+                    query,
+                    dp,
+                    compiled,
+                    isinstance(query, UpdateBase)
+                )
                 result_map = compiled._result_columns
             else:
                 if dp:

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -16,6 +16,7 @@ from ..utils import _TransactionContextManager, _SAConnectionContextManager
 def noop(k):
     return k
 
+
 class SAConnection:
 
     def __init__(self, connection, engine, compiled_cache=None):

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -93,6 +93,7 @@ class SAConnection:
         """
         executemany
         """
+        result_map = None
         if isinstance(query, str):
             await cursor.executemany(query, dps)
         elif isinstance(query, DDLElement):
@@ -114,13 +115,13 @@ class SAConnection:
                     )
                 )
             await cursor.executemany(str(compiled), params)
+            result_map = compiled._result_columns
         else:
             raise exc.ArgumentError(
                 "sql statement should be str or "
                 "SQLAlchemy data "
                 "selection/modification clause"
             )
-        result_map = compiled._result_columns
         ret = await create_result_proxy(
             self,
             cursor,
@@ -134,8 +135,8 @@ class SAConnection:
         cursor = await self._connection.cursor()
         dp = _distill_params(multiparams, params)
         if len(dp) > 1:
-            return await self._executemany(query, dp, cursor)
             # raise exc.ArgumentError("aiomysql doesn't support executemany")
+            return await self._executemany(query, dp, cursor)
         elif dp:
             dp = dp[0]
 

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -63,17 +63,71 @@ class SAConnection:
         """
         coro = self._execute(query, *multiparams, **params)
         return _SAConnectionContextManager(coro)
+    
+    def _base_params(self, query, dp, compiled, is_update):
+        """
+        handle params
+        """
+        if dp and isinstance(dp, (list, tuple)):
+            if is_update:
+                dp = {c.key: pval for c, pval in zip(query.table.c, dp)}
+            else:
+                raise exc.ArgumentError(
+                    "Don't mix sqlalchemy SELECT "
+                    "clause with positional "
+                    "parameters"
+                )
+        compiled_params = compiled.construct_params(dp)
+        processors = compiled._bind_processors
+        params = [{
+            key: (
+                processors[key](compiled_params[key])
+                if key in processors else compiled_params[key]
+            )
+            for key in compiled_params
+        }]
+        post_processed_params = self._dialect.execute_sequence_format(params)
+        return post_processed_params[0]
+
+    async def _executemany(self, query, dps, cursor):
+        """
+        executemany
+        """
+        if isinstance(query, str):
+            await cursor.executemany(query, dps)
+        elif isinstance(query, DDLElement):
+            raise exc.ArgumentError(
+                    "Don't mix sqlalchemy DDL clause "
+                    "and execution with parameters"
+                )
+        elif isinstance(query, ClauseElement):
+            compiled = query.compile(dialect=self._dialect)
+            params = []
+            is_update = isinstance(query, UpdateBase)
+            for dp in dps:
+                params.append(self._base_params(query, dp, compiled, is_update))
+            await cursor.executemany(str(compiled), params)
+        else:
+            raise exc.ArgumentError(
+                "sql statement should be str or "
+                "SQLAlchemy data "
+                "selection/modification clause"
+            )
+        result_map = compiled._result_columns
+        ret = await create_result_proxy(self, cursor, self._dialect, result_map)
+        self._weak_results.add(ret)
+        return ret
 
     async def _execute(self, query, *multiparams, **params):
         cursor = await self._connection.cursor()
         dp = _distill_params(multiparams, params)
         if len(dp) > 1:
-            raise exc.ArgumentError("aiomysql doesn't support executemany")
+            return await self._executemany(query, dp, cursor)
+            # raise exc.ArgumentError("aiomysql doesn't support executemany")
         elif dp:
             dp = dp[0]
 
         result_map = None
-
         if isinstance(query, str):
             await cursor.execute(query, dp or None)
         elif isinstance(query, ClauseElement):
@@ -90,35 +144,15 @@ class SAConnection:
                 compiled = query.compile(dialect=self._dialect)
 
             if not isinstance(query, DDLElement):
-                if dp and isinstance(dp, (list, tuple)):
-                    if isinstance(query, UpdateBase):
-                        dp = {c.key: pval
-                              for c, pval in zip(query.table.c, dp)}
-                    else:
-                        raise exc.ArgumentError("Don't mix sqlalchemy SELECT "
-                                                "clause with positional "
-                                                "parameters")
-                compiled_parameters = [compiled.construct_params(
-                    dp)]
-                processed_parameters = []
-                processors = compiled._bind_processors
-                for compiled_params in compiled_parameters:
-                    params = {key: (processors[key](compiled_params[key])
-                                    if key in processors
-                                    else compiled_params[key])
-                              for key in compiled_params}
-                    processed_parameters.append(params)
-                post_processed_params = self._dialect.execute_sequence_format(
-                    processed_parameters)
+                post_processed_params = self._base_params(query, dp, compiled, isinstance(query, UpdateBase))
                 result_map = compiled._result_columns
-
             else:
                 if dp:
                     raise exc.ArgumentError("Don't mix sqlalchemy DDL clause "
                                             "and execution with parameters")
-                post_processed_params = [compiled.construct_params()]
+                post_processed_params = compiled.construct_params()
                 result_map = None
-            await cursor.execute(str(compiled), post_processed_params[0])
+            await cursor.execute(str(compiled), post_processed_params)
         else:
             raise exc.ArgumentError("sql statement should be str or "
                                     "SQLAlchemy data "

--- a/aiomysql/sa/connection.py
+++ b/aiomysql/sa/connection.py
@@ -121,7 +121,12 @@ class SAConnection:
                 "selection/modification clause"
             )
         result_map = compiled._result_columns
-        ret = await create_result_proxy(self, cursor, self._dialect, result_map)
+        ret = await create_result_proxy(
+            self,
+            cursor,
+            self._dialect,
+            result_map
+        )
         self._weak_results.add(ret)
         return ret
 

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -269,10 +269,10 @@ class TestSAConnection(unittest.TestCase):
     def test_raw_insert_with_executemany(self):
         async def go():
             conn = await self.connect()
-            with self.assertRaises(sa.ArgumentError):
-                await conn.execute(
-                    "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
-                    [(2, 'third'), (3, 'forth')])
+            # with self.assertRaises(sa.ArgumentError):
+            await conn.execute(
+                "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
+                [(2, 'third'), (3, 'forth')])
         self.loop.run_until_complete(go())
 
     def test_raw_select_with_wildcard(self):

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -275,8 +275,15 @@ class TestSAConnection(unittest.TestCase):
                 "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
                 [{"id": 2, "name": 'third'}, {"id": 3, "name": 'forth'}])
             await conn.execute(
-                tbl.update().where(tbl.c.id==bindparam("id")).values({"name": bindparam("name")}),
-                [{"id": 2, "name": "t2"}, {"id": 3, "name": "t3"}]
+                tbl.update().where(
+                    tbl.c.id == bindparam("id")
+                ).values(
+                    {"name": bindparam("name")}
+                ),
+                [
+                    {"id": 2, "name": "t2"},
+                    {"id": 3, "name": "t3"}
+                ]
             )
             with self.assertRaises(sa.ArgumentError):
                 await conn.execute(

--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -272,7 +272,7 @@ class TestSAConnection(unittest.TestCase):
             # with self.assertRaises(sa.ArgumentError):
             await conn.execute(
                 "INSERT INTO sa_tbl (id, name) VALUES (%(id)s, %(name)s)",
-                [(2, 'third'), (3, 'forth')])
+                [{"id": 2, "name": 'third'}, {"id": 3, "name": 'forth'}])
         self.loop.run_until_complete(go())
 
     def test_raw_select_with_wildcard(self):


### PR DESCRIPTION
## run example
error: aiomysql doesn't support executemany

``` python
import asyncio
import sqlalchemy as sa
from sqlalchemy.sql.ddl import CreateTable, DropTable
from aiomysql.sa import create_engine
from sqlalchemy.sql.expression import bindparam

metadata = sa.MetaData()
User = sa.Table(
    'user',
    metadata,
    sa.Column(
        'id',
        sa.Integer,
        autoincrement=True,
        primary_key=True,
        nullable=False,
    ),
    sa.Column(
        'name',
        sa.String(16),
        nullable=False,
    )
)

async def test_executemany(loop):
    engine = await create_engine(
         user="aiomysql",
         db="test_pymysql",
         host="127.0.0.1",
         password="mypass",
         port=3306,
         loop=loop,
         echo=True,
    )
    async with engine.acquire() as conn:
        await conn.execute(CreateTable(User))
        await conn.execute(User.insert().values([{"name": "test1"}, {"name": "test2"}]))
        async with conn.execute(User.select()) as cursor:
            user = await cursor.fetchone()
            assert user.id == 1
            assert user.name == "test1"
            user = await cursor.fetchone()
            assert user.id == 2
            assert user.name == "test2"
        sql = User.update().where(User.c.id == bindparam("id")).values({"name": bindparam("name")})
        await conn.execute(sql, [{"id": 1, "name": "t1"}, {"id": 2, "name": "t2"}])
        async with conn.execute(User.select()) as cursor:
            user = await cursor.fetchone()
            assert user.id == 1
            assert user.name == "t1"
            user = await cursor.fetchone()
            assert user.id == 2
            assert user.name == "t2"


loop = asyncio.get_event_loop()
loop.run_until_complete(test_executemany(loop))

```