### PR TITLE
Add version-conditional uvloop install to requirements-dev.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ before_script:
     - "mysql -e 'DROP DATABASE IF EXISTS test_pymysql2; create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
 
 install:
-    - if python -c "import sys; sys.exit(sys.version_info < (3,5))"; then
-          pip install uvloop;
-      fi
     - pip install -Ur requirements-dev.txt
     - pip install .
     - pip install codecov

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,10 +73,6 @@ After that please install libraries required for development::
 
    $ pip install -r requirements-dev.txt
 
-We also recommend to install *ipdb* but it's on your own::
-
-   $ pip install ipdb
-
 Congratulations, you are ready to run the test suite
 
 Install database

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ docker==3.4.1
 sphinx==1.7.6
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy==1.2.10
+uvloop==0.11.2; python_version >= '3.5'


### PR DESCRIPTION
On python 3.5+ following the CONTRIBUTING steps fails when `tests/conftest.py` tries to `import uvloop`. This patch adds uvloop with a conditional on python >= 3.5, and removes the now unnecessary install step from the travis install steps.

Reproduces on stock Ubuntu 18.04.1 LTS with Python 3.6.5.