### PR TITLE
Don't reuse connections when StreamReader has an exception

### DIFF
--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -148,7 +148,7 @@ class Pool(asyncio.AbstractServer):
         n = 0
         while n < free_size:
             conn = self._free[-1]
-            if conn._reader.at_eof():
+            if conn._reader.at_eof() or conn._reader.exception():
                 self._free.pop()
                 conn.close()
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -492,6 +492,7 @@ async def test_cancelled_connection(pool_creator, loop):
         # If we receive [(1, 0)] - we retrieved old cursor's values
         assert list(res) == [(2, 0)]
 
+
 @pytest.mark.run_loop
 async def test_pool_with_connection_recycling(pool_creator, loop):
     pool = await pool_creator(minsize=1, maxsize=1, pool_recycle=3)
@@ -510,8 +511,9 @@ async def test_pool_with_connection_recycling(pool_creator, loop):
         val = await cur.fetchone()
         assert (1,) == val
 
+
 @pytest.mark.run_loop
-async def test_pool_does_not_reuse_connection_with_exception(pool_creator, loop):
+async def test_pool_drops_connection_with_exception(pool_creator, loop):
     pool = await pool_creator(minsize=1, maxsize=1)
 
     async with pool.get() as conn:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -492,7 +492,7 @@ async def test_cancelled_connection(pool_creator, loop):
         # If we receive [(1, 0)] - we retrieved old cursor's values
         assert list(res) == [(2, 0)]
 
-
+@pytest.mark.run_loop
 async def test_pool_with_connection_recycling(pool_creator, loop):
     pool = await pool_creator(minsize=1, maxsize=1, pool_recycle=3)
     async with pool.get() as conn:
@@ -509,3 +509,18 @@ async def test_pool_with_connection_recycling(pool_creator, loop):
         await cur.execute('SELECT 1;')
         val = await cur.fetchone()
         assert (1,) == val
+
+@pytest.mark.run_loop
+async def test_pool_does_not_reuse_connection_with_exception(pool_creator, loop):
+    pool = await pool_creator(minsize=1, maxsize=1)
+
+    async with pool.get() as conn:
+        cur = await conn.cursor()
+        await cur.execute('SELECT 1;')
+
+    connection, = pool._free
+    connection._reader.set_exception(IOError())
+
+    async with pool.get() as conn:
+        cur = await conn.cursor()
+        await cur.execute('SELECT 1;')

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -519,7 +519,7 @@ async def test_pool_does_not_reuse_connection_with_exception(pool_creator, loop)
         await cur.execute('SELECT 1;')
 
     connection, = pool._free
-    connection._reader.set_exception(IOError())
+    connection._writer._protocol.connection_lost(IOError())
 
     async with pool.get() as conn:
         cur = await conn.cursor()


### PR DESCRIPTION
In our production environment, we occasionally experience connection timeouts that "stick" in the aiomysql Pool. Every subsequent connection acquired from the pool will fail on first use.

My production environment full traceback (with private code redacted): https://gist.github.com/TimothyFitz/2d929f907c4cad47a7c8da8e0944b19e

This PR adds a test to simulate our production failure by directly calling `connection_lost` on a connection in the free pool.

The pool code already checks for gracefully closed connection via `_reader.at_eof()`. The fix is to also check for `_reader.exception()`.

I think #132 accidentally conflated two issues, and the fix identified there is needed in addition to pool recycling: https://github.com/aio-libs/aiomysql/issues/132#issuecomment-336651086

Tested on:
(production) Ubuntu 16.04.5 LTS, Python 3.5.2, aiomysql 0.0.17 + this patch
(dev laptop) Ubuntu 18.04.1 LTS, Python 3.6.5, this PR (master + patch)

