### PR TITLE
improve basic usage in pool document

### DIFF
--- a/docs/pool.rst
+++ b/docs/pool.rst
@@ -20,14 +20,14 @@ The basic usage is::
                                                user='root', password='',
                                                db='mysql', loop=loop, autocommit=False)
 
-        with (yield from pool) as conn:
-            cur = yield from conn.cursor()
-            yield from cur.execute("SELECT 10")
-            # print(cur.description)
-            (r,) = yield from cur.fetchone()
-           assert r == 10
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT 10")
+                # print(cur.description)
+                (r,) = await cur.fetchone()
+                assert r == 10
         pool.close()
-        yield from pool.wait_closed()
+        await pool.wait_closed()
 
     loop.run_until_complete(go())
 


### PR DESCRIPTION
This example has some issues:
1. `with (yield from pool) as conn` has been deprecated in #283 
2. The `cursor` is not closed in the example. It uses context manager for `conn` but not for `cursor`.
3. The indent of line 28 is wrong.

Besides, the basic usage of `pool` is in the `README.rst` of the project.
I don't think one more example is valuable.