### PR TITLE
remove basic example in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Mailing List
 https://groups.google.com/forum/#!forum/aio-libs
 
 
-Basic Example
+Basic
 -------------
 
 **aiomysql** based on PyMySQL_ , and provides same api, you just need
@@ -44,28 +44,6 @@ to use  ``await conn.f()`` or ``yield from conn.f()`` instead of calling
 
 Properties are unchanged, so ``conn.prop`` is correct as well as
 ``conn.prop = val``.
-
-
-.. code:: python
-
-    import asyncio
-    from aiomysql import create_pool
-
-
-    loop = asyncio.get_event_loop()
-
-    async def go():
-        async with create_pool(host='127.0.0.1', port=3306,
-                               user='root', password='',
-                               db='mysql', loop=loop) as pool:
-            async with pool.get() as conn:
-                async with conn.cursor() as cur:
-                    await cur.execute("SELECT 42;")
-                    value = await cur.fetchone()
-                    print(value)
-
-
-    loop.run_until_complete(go())
 
 
 Connection Pool


### PR DESCRIPTION
The basic example is almost the same with the following connection pool example.
And it uses `pool.get()`, which was deprecated in 2016, 8c1117948c144420bb37f712b284810f45750f5e