### PR TITLE
Run tests for python 3.7 in CI and fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
     - 3.5.3
     - 3.6
+    - 3.7
 
 env:
     matrix:
@@ -28,6 +29,18 @@ matrix:
               mariadb: 10.1
         - python: 3.6
           env: PYTHONASYNCIODEBUG=
+          addons:
+              mysql: 5.7
+        - python: 3.7
+          dist: xenial
+          sudo: true
+          env: PYTHONASYNCIODEBUG=1
+          addons:
+              mariadb: 10.1
+        - python: 3.7
+          dist: xenial
+          sudo: true
+          env: PYTHONASYNCIODEBUG=1
           addons:
               mysql: 5.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+sudo: true
 language: python
 
 python:
@@ -32,14 +34,10 @@ matrix:
           addons:
               mysql: 5.7
         - python: 3.7
-          dist: xenial
-          sudo: true
           env: PYTHONASYNCIODEBUG=1
           addons:
               mariadb: 10.1
         - python: 3.7
-          dist: xenial
-          sudo: true
           env: PYTHONASYNCIODEBUG=1
           addons:
               mysql: 5.7

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -447,7 +447,7 @@ class ResultProxy:
         else:
             return None
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/aiomysql/utils.py
+++ b/aiomysql/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-
 from collections.abc import Coroutine
 
 


### PR DESCRIPTION
Related to #357 and #317. I.e., I see the following errors with Python 3.7 -

```bash
$ py.test -s -v -x ./tests/                                                                                                    1.8m  Sun Jan 27 21:24:05 2019
Test session starts (platform: darwin, Python 3.7.2, pytest 3.9.1, pytest-sugar 0.9.1)
cachedir: .pytest_cache
rootdir: /Users/pradipcaulagi/jipu/src/aiomysql, inifile:
plugins: sugar-0.9.1, cov-2.6.0

 tests/test_async_iter.py::test_async_cursor[asyncio-5.6] ✓                                                                                                                                    0%
 tests/test_async_iter.py::test_async_cursor_server_side[asyncio-5.6] ✓                                                                                                                        0% ▏

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_async_iter_over_sa_result[asyncio-5.6] ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

mysql_params = {'db': 'test_pymysql', 'host': 'localhost', 'local_infile': True, 'password': '', ...}, table = None, loop = <_UnixSelectorEventLoop running=False closed=False debug=False>

    @pytest.mark.run_loop
    async def test_async_iter_over_sa_result(mysql_params, table, loop):
        ret = []
        engine = await sa.create_engine(**mysql_params, loop=loop)
        conn = await engine.acquire()

>       async for i in (await conn.execute(tbl.select())):
E       TypeError: 'async for' received an object from __aiter__ that does not implement __anext__: coroutine

tests/test_async_iter.py:61: TypeError
```

The fixes are based on [aiopg utils](https://github.com/aio-libs/aiopg/blob/3fd1dede81a7f6442c763b0b7f67b868c706be46/aiopg/utils.py#L88).

I added running tests for **python 3.7 as part of CI**.