### PR TITLE
import version from __init.py__

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -177,11 +177,11 @@ class Connection:
         self.server_public_key = server_public_key
         self.salt = None
 
-        # TODO somehow import version from __init__.py
+        from . import __version__
         self._connect_attrs = {
             '_client_name': 'aiomysql',
             '_pid': str(os.getpid()),
-            '_client_version': '0.0.16',
+            '_client_version': __version__,
         }
         if program_name:
             self._connect_attrs["program_name"] = program_name


### PR DESCRIPTION
I see the comment "# TODO somehow import version from \__init__.py" in the connection.py.
Since A import B and B import A will cause **cycle import**, \__init__.py has imported sth from conncetion, so I import version in the function inner to avoid the problem.