### PR TITLE
Fix legacy __aiter__ methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ Requirements
 
 
 .. _Python: https://www.python.org
-.. _asyncio: http://docs.python.org/3.4/library/asyncio.html
+.. _asyncio: http://docs.python.org/3.5/library/asyncio.html
 .. _aiopg: https://github.com/aio-libs/aiopg
 .. _PyMySQL: https://github.com/PyMySQL/PyMySQL
 .. _Tornado-MySQL: https://github.com/PyMySQL/Tornado-MySQL

--- a/aiomysql/sa/result.py
+++ b/aiomysql/sa/result.py
@@ -447,7 +447,7 @@ class ResultProxy:
         else:
             return None
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to aiomysql's documentation!
 ====================================
 
 .. _GitHub: https://github.com/aio-libs/aiomysql
-.. _asyncio: http://docs.python.org/3.4/library/asyncio.html
+.. _asyncio: http://docs.python.org/3.5/library/asyncio.html
 .. _aiopg: https://github.com/aio-libs/aiopg
 .. _Tornado-MySQL: https://github.com/PyMySQL/Tornado-MySQL
 .. _aio-libs: https://github.com/aio-libs
@@ -105,7 +105,7 @@ coverage reports.
 Dependencies
 ------------
 
-- Python 3.3 and :mod:`asyncio` or Python 3.4+
+- Python 3.5.3+
 - :term:`PyMySQL`
 - aiomysql.sa requires :term:`sqlalchemy`.
 


### PR DESCRIPTION
This allows the `async for` syntax to be used with `ResultProxy` and `Cursor` objects in python 3.7.

Fixes #394 
Fixes #386 
Fixes #317 