### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ target/
 # rope
 .ropeproject
 
+# pyenv
+.python-version
 
 tests/fixtures/my.cnf
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds `.python-version` (which is used to specify pyenv version) to the list of ignored files.

## Are there changes in behavior for the user?

As a developer of the project, I can specify python version for pyenv that is configured for the project.