### PR TITLE
Fix invalid datetime value in test_issue_8

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -76,7 +76,7 @@ class TestOldIssues(base.AIOPyMySQLTestCase):
         yield from c.execute("drop table if exists test")
         yield from c.execute("""CREATE TABLE `test` (`station` int(10) NOT
             NULL DEFAULT '0', `dh`
-            datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+            datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
             `echeance` int(1) NOT NULL DEFAULT '0', `me` double DEFAULT NULL,
             `mo` double DEFAULT NULL, PRIMARY
             KEY (`station`,`dh`,`echeance`)) ENGINE=MyISAM DEFAULT


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix unix socket connection and datetime value in tests.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No behavior changes.

## Related issue number

https://github.com/aio-libs/aiomysql/issues/338
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] ~~Unit tests for the changes exist~~
- [x] ~~Documentation reflects the changes~~
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
