### PR TITLE
Fix  aiomysql.sa in Python 3.7 and run tests for python 3.7 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: xenial
 language: python
 
 python:
     - 3.5.3
     - 3.6
+    - 3.7
 
 env:
     matrix:
@@ -11,22 +13,27 @@ env:
 
 services:
     - docker
+    - mysql
 
 matrix:
    include:
         - python: 3.6
+          dist: trusty
           env: PYTHONASYNCIODEBUG=
           addons:
               mariadb: 5.5
         - python: 3.6
+          dist: trusty
           env: PYTHONASYNCIODEBUG=1
           addons:
               mariadb: 10.0
         - python: 3.6
+          dist: trusty
           env: PYTHONASYNCIODEBUG=
           addons:
               mariadb: 10.1
         - python: 3.6
+          dist: trusty
           env: PYTHONASYNCIODEBUG=
           addons:
               mysql: 5.7

--- a/aiomysql/utils.py
+++ b/aiomysql/utils.py
@@ -70,9 +70,19 @@ class _PoolContextManager(_ContextManager):
 
 
 class _SAConnectionContextManager(_ContextManager):
-    async def __aiter__(self):
-        result = await self._coro
-        return result
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._obj is None:
+            self._obj = await self._coro
+
+        try:
+            return (await self._obj.__anext__())
+        except StopAsyncIteration:
+            await self._obj.close()
+            self._obj = None
+            raise
 
 
 class _TransactionContextManager(_ContextManager):


### PR DESCRIPTION
## What do these changes do?
Fix async iterator protocol in aiomysql.utils._SAConnectionContextManager,
and run tests for python 3.7 in CI.

<!-- Please give a short brief about these changes. -->
1. Add   `__aiter__` and  `__anext__` methods for `_SAConnectionContextManager`
2. Update .travis.yml for Python 3.7 


## Are there changes in behavior for the user?
No changes.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
[#410](https://github.com/aio-libs/aiomysql/issues/410)


<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
