### PR TITLE
Catching connection lost on _write_bytes

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -514,10 +514,7 @@ class Connection:
             if self.autocommit_mode is not None:
                 await self.autocommit(self.autocommit_mode)
         except Exception as e:
-            if self._writer:
-                self._writer.transport.close()
-            self._reader = None
-            self._writer = None
+            self.close()
             raise OperationalError(2003,
                                    "Can't connect to MySQL server on %r" %
                                    self._host) from e
@@ -605,7 +602,12 @@ class Connection:
         return data
 
     def _write_bytes(self, data):
-        return self._writer.write(data)
+        try:
+            return self._writer.write(data)
+        except RuntimeError as e:
+            self.close()
+            msg = "Lost connection to MySQL server during query (%s)" % (e,)
+            raise OperationalError(2013, msg) from e
 
     async def _read_query_result(self, unbuffered=False):
         self._result = None


### PR DESCRIPTION
It's possible the connection can dropping without any notification. There was caught the connection lost while making a request to MySQL through peewee_async:
```
Traceback (most recent call last):
...
  File "/usr/lib/python3.6/site-packages/peewee_async.py", line 1441, in _run_sql
    await cursor.execute(operation, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/aiomysql/cursors.py", line 237, in execute
    await self._query(query)
  File "/usr/lib/python3.6/site-packages/aiomysql/cursors.py", line 455, in _query
    await conn.query(q)
  File "/usr/lib/python3.6/site-packages/aiomysql/connection.py", line 419, in query
    await self._execute_command(COMMAND.COM_QUERY, sql)
  File "/usr/lib/python3.6/site-packages/aiomysql/connection.py", line 648, in _execute_command
    self._write_bytes(prelude + sql[:chunk_size - 1])
  File "/usr/lib/python3.6/site-packages/aiomysql/connection.py", line 593, in _write_bytes
    return self._writer.write(data)
  File "/usr/lib/python3.6/asyncio/streams.py", line 300, in write
    self._transport.write(data)
  File "uvloop/handles/stream.pyx", line 671, in uvloop.loop.UVStream.write
  File "uvloop/handles/handle.pyx", line 159, in uvloop.loop.UVHandle._ensure_alive
RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x2742598>; the handler is closed
```
Because of the connection remains in a wrong state (`self._writer.transport.closed == True`, but `self.closed == False`), it is put to the pool again on `release()`.