### PR TITLE
added support for sqlalchemy default parameters #455

### DIFF
--- a/tests/sa/test_sa_default.py
+++ b/tests/sa/test_sa_default.py
@@ -1,0 +1,105 @@
+import datetime
+
+import pytest
+from sqlalchemy import MetaData, Table, Column, Integer, String
+from sqlalchemy import func, DateTime, Boolean
+
+from aiomysql import sa
+
+meta = MetaData()
+table = Table('sa_tbl_default_test', meta,
+              Column('id', Integer, nullable=False, primary_key=True),
+              Column('string_length', Integer,
+                     default=func.length('qwerty')),
+              Column('number', Integer, default=100, nullable=False),
+              Column('description', String(255), nullable=False,
+                     default='default test'),
+              Column('created_at', DateTime,
+                     default=datetime.datetime.now),
+              Column('enabled', Boolean, default=True))
+
+
+@pytest.fixture()
+def make_engine(mysql_params, connection):
+    async def _make_engine(**kwargs):
+        return (await sa.create_engine(db=mysql_params['db'],
+                                       user=mysql_params['user'],
+                                       password=mysql_params['password'],
+                                       host=mysql_params['host'],
+                                       port=mysql_params['port'],
+                                       minsize=10,
+                                       **kwargs))
+
+    return _make_engine
+
+
+async def start(engine):
+    async with engine.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS sa_tbl_default_test")
+        await conn.execute("CREATE TABLE sa_tbl_default_test "
+                           "(id integer,"
+                           " string_length integer, "
+                           "number integer,"
+                           " description VARCHAR(255), "
+                           "created_at DATETIME(6), "
+                           "enabled TINYINT)")
+
+
+@pytest.mark.run_loop
+async def test_default_fields(make_engine):
+    engine = await make_engine()
+    await start(engine)
+    async with engine.acquire() as conn:
+        await conn.execute(table.insert().values())
+        res = await conn.execute(table.select())
+        row = await res.fetchone()
+        assert row.string_length == 6
+        assert row.number == 100
+        assert row.description == 'default test'
+        assert row.enabled is True
+        assert type(row.created_at) == datetime.datetime
+
+
+@pytest.mark.run_loop
+async def test_default_fields_isnull(make_engine):
+    engine = await make_engine()
+    await start(engine)
+    async with engine.acquire() as conn:
+        created_at = None
+        enabled = False
+        await conn.execute(table.insert().values(
+            enabled=enabled,
+            created_at=created_at,
+        ))
+
+        res = await conn.execute(table.select())
+        row = await res.fetchone()
+        assert row.number == 100
+        assert row.string_length == 6
+        assert row.description == 'default test'
+        assert row.enabled == enabled
+        assert row.created_at == created_at
+
+
+async def test_default_fields_edit(make_engine):
+    engine = await make_engine()
+    await start(engine)
+    async with engine.acquire() as conn:
+        created_at = datetime.datetime.now()
+        description = 'new descr'
+        enabled = False
+        number = 111
+        await conn.execute(table.insert().values(
+            description=description,
+            enabled=enabled,
+            created_at=created_at,
+            number=number,
+        ))
+
+        res = await conn.execute(table.select())
+        row = await res.fetchone()
+        assert row.number == number
+        assert row.string_length == 6
+        assert row.description == description
+        assert row.enabled == enabled
+        assert row.created_at == created_at


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix https://github.com/aio-libs/aiomysql/issues/455

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No changes

## Related issue number

https://github.com/aio-libs/aiomysql/issues/455

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
