### PR TITLE
459.bugfix

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -299,6 +299,15 @@ class Connection:
         self._writer = None
         self._reader = None
 
+    async def close_async(self):
+        """Close socket connection"""
+        if self._writer:
+            self._writer.close()
+            await self._writer.wait_closed()
+
+        self._writer = None
+        self._reader = None
+
     async def ensure_closed(self):
         """Send quit command and then close socket connection"""
         if self._writer is None:

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -114,7 +114,7 @@ class Pool(asyncio.AbstractServer):
 
         while self._free:
             conn = self._free.popleft()
-            conn.close()
+            await conn.close_async()
 
         async with self._cond:
             while self.size > self.freesize:


### PR DESCRIPTION
## What do these changes do?

When running in a pool, upon close, fixes the error:

`An open stream object is being garbage collected; call "stream.close()" explicitly.`