### PR TITLE
Correct Connection user/password becoming tuples during _request_authentication

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -711,6 +711,11 @@ class Connection:
             )
 
         charset_id = charset_by_name(self.charset).id
+        # Unsure why, but user appears to become a tuple at some point. This fixes that.
+        if isinstance(self.user, tuple):
+            _user = self.user[0]
+            self.user = _user
+        
         if isinstance(self.user, str):
             _user = self.user.encode(self.encoding)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This is a bugfix to fix `aiomysql.create_pool` - as in my local environment, I simply couldn't create a pool connection without getting a TypeError + OperationalError.

In the constructor of `aiomysql.Connection`, I've added a check for `self._user` and `self._password` which unwraps _user/_password's first value if they're detected to be a tuple.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

I don't think this will break any behaviour, as it's simply a bug fix. Without this fix, you can't use `aiomysql.create_pool` due to the username/password somehow being converted to tuple's, breaking concatenation.

When I was testing `aiomysql` within a Quart project running Python 3.8, I noticed there was a `TypeError` being raised during connection, related to the `_user` variable being a tuple.

I tried sending `user` to `aiomysql.create_pool` as `str`, `bytes`, and even as a tuple, but I'd get this same error over and over again:

```
An open stream object is being garbage collected; call "stream.close()" explicitly.
Traceback (most recent call last):
  File "(VENV)/lib/python3.8/site-packages/aiomysql/connection.py", line 505, in _connect
    await self._request_authentication()
  File "(VENV)/lib/python3.8/site-packages/aiomysql/connection.py", line 728, in _request_authentication
    data = data_init + _user + b'\0'
TypeError: can't concat tuple to bytes
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "(VENV)/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3329, in run_code
    await eval(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-11668a92a80b>", line 1, in <module>
    await get_server_variables('sql.example.org')
  File "/Users/someguy123/aio_project/app/core.py", line 80, in get_server_variables
    pool = await get_sql_pool(server, clean=True)
  File "/Users/someguy123/aio_project/app/core.py", line 62, in get_sql_pool
    return await _get_sql_pool(server, loop=loop)
  File "/Users/someguy123/aio_project/app/core.py", line 40, in _get_sql_pool
    return await aiomysql.create_pool(
  File "(VENV)/lib/python3.8/site-packages/aiomysql/pool.py", line 29, in _create_pool
    await pool._fill_free_pool(False)
  File "(VENV)/lib/python3.8/site-packages/aiomysql/pool.py", line 167, in _fill_free_pool
    conn = await connect(echo=self._echo, loop=self._loop,
  File "(VENV)/lib/python3.8/site-packages/aiomysql/connection.py", line 75, in _connect
    await conn._connect()
  File "(VENV)/lib/python3.8/site-packages/aiomysql/connection.py", line 523, in _connect
    raise OperationalError(2003,
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'sql.example.org'")
```


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
