### PR TITLE
Update dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ ipdb==0.13.2
 ipython==7.13.0
 pytest==5.4.1
 pytest-cov==2.8.1
-pytest-sugar==0.9.1
+pytest-sugar==0.9.3
 PyMySQL>=0.9,<=0.9.2
 docker==3.5.1
 sphinx==1.8.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==5.1
 flake8==3.7.9
-ipdb==0.11
+ipdb==0.13.2
 ipython==7.0.1
 pytest==3.9.1
 pytest-cov==2.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ PyMySQL==0.9.3
 docker==4.2.0
 sphinx==3.0.3
 sphinxcontrib-asyncio==0.2.0
-sqlalchemy==1.2.12
+sqlalchemy==1.3.16
 uvloop==0.11.2; python_version >= '3.5'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest==5.4.1
 pytest-cov==2.8.1
 pytest-sugar==0.9.3
 PyMySQL==0.9.3
-docker==3.5.1
+docker==4.2.0
 sphinx==1.8.1
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy==1.2.12

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ flake8==3.7.9
 ipdb==0.13.2
 ipython==7.13.0
 pytest==5.4.1
-pytest-cov==2.6.0
+pytest-cov==2.8.1
 pytest-sugar==0.9.1
 PyMySQL>=0.9,<=0.9.2
 docker==3.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage==5.1
 flake8==3.7.9
 ipdb==0.13.2
 ipython==7.13.0
-pytest==3.9.1
+pytest==5.4.1
 pytest-cov==2.6.0
 pytest-sugar==0.9.1
 PyMySQL>=0.9,<=0.9.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ docker==4.2.0
 sphinx==3.0.3
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy==1.3.16
-uvloop==0.11.2; python_version >= '3.5'
+uvloop==0.14.0; python_version >= '3.5'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ ipython==7.13.0
 pytest==5.4.1
 pytest-cov==2.8.1
 pytest-sugar==0.9.3
-PyMySQL>=0.9,<=0.9.2
+PyMySQL==0.9.3
 docker==3.5.1
 sphinx==1.8.1
 sphinxcontrib-asyncio==0.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==5.1
 flake8==3.7.9
 ipdb==0.13.2
-ipython==7.0.1
+ipython==7.13.0
 pytest==3.9.1
 pytest-cov==2.6.0
 pytest-sugar==0.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage==5.1
-flake8==3.5.0
+flake8==3.7.9
 ipdb==0.11
 ipython==7.0.1
 pytest==3.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
-coverage==5.1
-flake8==3.7.9
-ipdb==0.13.2
-ipython==7.13.0
-pytest==5.4.1
-pytest-cov==2.8.1
-pytest-sugar==0.9.3
-PyMySQL==0.9.3
-docker==4.2.0
-sphinx==3.0.3
+coverage>=4.5.1,<=5.1
+flake8>=3.5.0,<=3.7.9
+ipdb>=0.11,<=0.13.2
+ipython>=7.0.1,<=7.13.0
+pytest>=3.9.1,<=5.4.1
+pytest-cov>=2.6.0,<=2.8.1
+pytest-sugar>=0.9.1,<=0.9.3
+PyMySQL>=0.9,<=0.9.3
+docker>=3.5.1,<=4.2.0
+sphinx>=1.8.1, <=3.0.3
 sphinxcontrib-asyncio==0.2.0
-sqlalchemy==1.3.16
-uvloop==0.14.0; python_version >= '3.5'
+sqlalchemy>1.2.12,<=1.3.16
+uvloop>=0.11.2,<=0.14.0; python_version >= '3.5'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pytest-cov==2.8.1
 pytest-sugar==0.9.3
 PyMySQL==0.9.3
 docker==4.2.0
-sphinx==1.8.1
+sphinx==3.0.3
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy==1.2.12
 uvloop==0.11.2; python_version >= '3.5'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-coverage==4.5.1
+coverage==5.1
 flake8==3.5.0
 ipdb==0.11
 ipython==7.0.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['PyMySQL>=0.9,<=0.9.2']
+install_requires = ['PyMySQL>=0.9,<=0.9.3']
 
 PY_VER = sys.version_info
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,10 +216,9 @@ def docker():
 
 @pytest.fixture(autouse=True)
 def ensure_mysql_verison(request, mysql_tag):
-    if request.node.get_closest_marker('mysql_verison'):
-        if request.node.get_closest_marker('mysql_verison').args[0] != mysql_tag:
-            pytest.skip('Not applicable for '
-                        'MySQL version: {0}'.format(mysql_tag))
+    mysql_version = request.node.get_closest_marker('mysql_verison')
+    if mysql_version and mysql_version.args[0] != mysql_tag:
+        pytest.skip('Not applicable for MySQL version: {0}'.format(mysql_tag))
 
 
 @pytest.fixture(scope='session')
@@ -277,7 +276,7 @@ def mysql_server(unused_port, docker, session_id,
             'ssl': ctx
         }
         delay = 0.001
-        for i in range(100):
+        for _ in range(100):
             try:
                 connection = pymysql.connect(
                     db='mysql',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import sys
 import time
 import uuid
 
+from distutils.version import StrictVersion
 from docker import APIClient
 
 import aiomysql
@@ -216,7 +217,11 @@ def docker():
 
 @pytest.fixture(autouse=True)
 def ensure_mysql_verison(request, mysql_tag):
-    mysql_version = request.node.get_closest_marker('mysql_verison')
+    if StrictVersion(pytest.__version__) >= StrictVersion('4.0.0'):
+        mysql_version = request.node.get_closest_marker('mysql_verison')
+    else:
+        mysql_version = request.node.get_marker('mysql_verison')
+
     if mysql_version and mysql_version.args[0] != mysql_tag:
         pytest.skip('Not applicable for MySQL version: {0}'.format(mysql_tag))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,8 +216,8 @@ def docker():
 
 @pytest.fixture(autouse=True)
 def ensure_mysql_verison(request, mysql_tag):
-    if request.node.get_marker('mysql_verison'):
-        if request.node.get_marker('mysql_verison').args[0] != mysql_tag:
+    if request.node.get_closest_marker('mysql_verison'):
+        if request.node.get_closest_marker('mysql_verison').args[0] != mysql_tag:
             pytest.skip('Not applicable for '
                         'MySQL version: {0}'.format(mysql_tag))
 


### PR DESCRIPTION
## What do these changes do?

- Update coverage from 4.5.1 to 5.1.
- Update flake8 from 3.5.0 to 3.7.9.
- Update ipdb from 0.11 to 0.13.2.
- Update ipython from 7.0.1 to 7.13.0.
- Update pytest from 3.9.1 to 5.4.1.
- Update pytest-cov from 2.6.0 to 2.8.1.
- Update pytest-cov from 2.6.0 to 2.8.1.
- Update pytest-sugar from 0.9.1 to 0.9.3.
- Update pymysql to latest version 0.9.3
- Update docker from 3.5.1 to 4.2.0.
- Update sphinx from 1.8.1 to 3.0.3.
- Update sqlalchemy from 1.2.12 to 1.3.16
- Update uvloop from 0.11.2 to 0.14.0