### PR TITLE
Fix loop DeprecationWarning in Python 3.8

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -487,8 +487,7 @@ class Connection:
                     asyncio.wait_for(
                         asyncio.open_connection(
                             self._host,
-                            self._port,
-                            loop=self._loop),
+                            self._port),
                         timeout=self.connect_timeout)
                 self._set_keep_alive()
                 self.host_info = "socket %s:%d" % (self._host, self._port)


### PR DESCRIPTION
## What do these changes do?

Fix `DeprecationWarning` by not using the `loop` argument.

```
  .../lib/python3.8/asyncio/tasks.py:455: DeprecationWarning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
    return await fut
```

## Are there changes in behavior for the user?

N/A.

## Related issue number

N/A.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
