### PR TITLE
Support python 3.7 and 3.8 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
     - 3.6
+    - 3.7
+    - 3.8
 
 env:
     matrix:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,18 @@ else:
     uvloop = None
 
 
+@pytest.fixture
+def disable_gc():
+    gc_enabled = gc.isenabled()
+    if gc_enabled:
+        gc.disable()
+        gc.collect()
+    yield
+    if gc_enabled:
+        gc.collect()
+        gc.enable()
+
+
 @pytest.fixture(scope='session')
 def unused_port():
     def f():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -219,6 +219,7 @@ async def test_connection_double_ensure_closed(connection_creator):
 
 
 @pytest.mark.run_loop
+@pytest.mark.usefixtures("disable_gc")
 async def test___del__(connection_creator):
     conn = await connection_creator()
     with pytest.warns(ResourceWarning):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

* Fix tests to pass on python 3.7 and 3.8 versions
* Support python 3.7 and 3.8 in Travis CI

