### PR TITLE
ENH: use of echo at connection, and new cursor with echo option from …

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -387,17 +387,20 @@ class Connection:
             return s.replace("'", "''")
         return escape_string(s)
 
-    def cursor(self, *cursors):
+    def cursor(self, echo=None, *cursors):
         """Instantiates and returns a cursor
 
         By default, :class:`Cursor` is returned. It is possible to also give a
         custom cursor through the cursor_class parameter, but it needs to
         be a subclass  of :class:`Cursor`
 
-        :param cursor: custom cursor class.
+        :param cursors: custom cursor class.
+        :param echo: create cursor with echo option
         :returns: instance of cursor, by default :class:`Cursor`
         :raises TypeError: cursor_class is not a subclass of Cursor.
         """
+        if echo is None:
+            echo = self._echo
         self._ensure_alive()
         self._last_usage = self._loop.time()
         try:
@@ -407,14 +410,14 @@ class Connection:
         except TypeError:
             raise TypeError('Custom cursor must be subclass of Cursor')
         if cursors and len(cursors) == 1:
-            cur = cursors[0](self, self._echo)
+            cur = cursors[0](self, echo)
         elif cursors:
             cursor_name = ''.join(map(lambda x: x.__name__, cursors)) \
                 .replace('Cursor', '') + 'Cursor'
             cursor_class = type(cursor_name, cursors, {})
-            cur = cursor_class(self, self._echo)
+            cur = cursor_class(self, echo)
         else:
-            cur = self.cursorclass(self, self._echo)
+            cur = self.cursorclass(self, echo)
         fut = self._loop.create_future()
         fut.set_result(cur)
         return _ContextManager(fut)
@@ -656,6 +659,9 @@ class Connection:
 
         if isinstance(sql, str):
             sql = sql.encode(self._encoding)
+
+        if self._echo:
+            logger.debug("COMMAND", extra={"sql": sql, "command": command})
 
         chunk_size = min(MAX_PACKET_LEN, len(sql) + 1)  # +1 is for command
 


### PR DESCRIPTION
…connection

<!-- Thank you for your contribution! -->

## What do these changes do?

Include logger.debug() message at _execute() connection function

## Are there changes in behavior for the user?

yes, when connection echo = True, will log more messages, instead of only cursor echo messages, but it's much much more usefull since we can trace autocommit , commit, begin, rollback messages, this helps a lot when debuging deadlocks

## Related issue number

#498

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
