### PR TITLE
Issue converting fetchall() response to a string so I can use it.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,13 +71,7 @@ def mysql_params():
 
 @pytest.yield_fixture
 def cursor(connection, loop):
-    # TODO: fix this workaround
-    @asyncio.coroutine
-    def f():
-        cur = yield from connection.cursor()
-        return cur
-
-    cur = loop.run_until_complete(f())
+    cur = loop.run_until_complete(connection.cursor())
     yield cur
     loop.run_until_complete(cur.close())
 


### PR DESCRIPTION
So, I am wanting to grab the DB name which I have done but it returns it like so '('information_schema',)' now I cannot use it like this as if I tell the cursor to use the response it doesn't work. 

Anyone know how I can convert this and just get the 'information_schema' part and not the rest?