### PR TITLE
Port pymysql support for percent signs

### DIFF
--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -274,7 +274,7 @@ class Cursor:
 
         m = RE_INSERT_VALUES.match(query)
         if m:
-            q_prefix = m.group(1)
+            q_prefix = m.group(1) % ()
             q_values = m.group(2).rstrip()
             q_postfix = m.group(3) or ''
             assert q_values[0] == '(' and q_values[-1] == ')'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This commit ports the second part of
https://github.com/PyMySQL/PyMySQL/commit/6bb4cdd69fac770fa967aa26130cfd5cdcf533e0
from PyMySQL.  This allows the treatment of percent signs in
SQL statements to be consistent within executemany().

E.g.::

     cursor.execute("SELECT * FROM `percent%%table`", {})

Will emit SELECT from a table named "percent%table".

The patch allows::

     cursor.executemany(
         "INSERT INTO `percent%%table` VALUES (%s, %s)",
         [(1, 2)]
     )

To also work consistently.


## Are there changes in behavior for the user?

If an end-user application is making use of executemany() with a SQL statement that refers to literal percent signs, they will now need to be doubled.   this is already the behavior of execute().

## Related issue number

nope
