### PR TITLE
vendor pymysql byte/int utils

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -16,7 +16,6 @@ from pymysql.constants import SERVER_STATUS
 from pymysql.constants import CLIENT
 from pymysql.constants import COMMAND
 from pymysql.constants import FIELD_TYPE
-from pymysql.util import byte2int, int2byte
 from pymysql.converters import (escape_item, encoders, decoders,
                                 escape_string, escape_bytes_prefixed, through)
 from pymysql.err import (Warning, Error,
@@ -28,18 +27,17 @@ from pymysql.err import (Warning, Error,
 from pymysql.connections import TEXT_TYPES, MAX_PACKET_LEN, DEFAULT_CHARSET
 from pymysql.connections import _auth
 
-from pymysql.connections import pack_int24
 
 from pymysql.connections import MysqlPacket
 from pymysql.connections import FieldDescriptorPacket
 from pymysql.connections import EOFPacketWrapper
 from pymysql.connections import OKPacketWrapper
 from pymysql.connections import LoadLocalPacketWrapper
-from pymysql.connections import lenenc_int
 
 # from aiomysql.utils import _convert_to_str
 from .cursors import Cursor
-from .utils import _ConnectionContextManager, _ContextManager
+from .utils import (_ConnectionContextManager, _ContextManager,
+                    int2byte, byte2int, pack_int24, lenenc_int)
 from .log import logger
 
 DEFAULT_USER = getpass.getuser()

--- a/aiomysql/utils.py
+++ b/aiomysql/utils.py
@@ -1,5 +1,37 @@
 from collections.abc import Coroutine
 
+import struct
+
+
+def byte2int(b):
+    if isinstance(b, int):
+        return b
+    else:
+        return struct.unpack("!B", b)[0]
+
+
+def int2byte(i):
+    return struct.pack("!B", i)
+
+
+
+def pack_int24(n):
+    return struct.pack('<I', n)[:3]
+
+# https://dev.mysql.com/doc/internals/en/integer.html#packet-Protocol::LengthEncodedInteger
+def lenenc_int(i):
+    if (i < 0):
+        raise ValueError("Encoding %d is less than 0 - no representation in LengthEncodedInteger" % i)
+    elif (i < 0xfb):
+        return int2byte(i)
+    elif (i < (1 << 16)):
+        return b'\xfc' + struct.pack('<H', i)
+    elif (i < (1 << 24)):
+        return b'\xfd' + struct.pack('<I', i)[:3]
+    elif (i < (1 << 64)):
+        return b'\xfe' + struct.pack('<Q', i)
+    else:
+        raise ValueError("Encoding %x is larger than %x - no representation in LengthEncodedInteger" % (i, (1 << 64)))
 
 class _ContextManager(Coroutine):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ ipython>=7.0.1,<=7.13.0
 pytest>=3.9.1,<=5.4.1
 pytest-cov>=2.6.0,<=2.8.1
 pytest-sugar>=0.9.1,<=0.9.3
-PyMySQL>=0.9,<=0.9.3
+PyMySQL>=0.9,<1.1
 docker>=3.5.1,<=4.2.0
 sphinx>=1.8.1, <=3.0.3
 sphinxcontrib-asyncio==0.2.0


### PR DESCRIPTION
PyMySQL 1.0.0 has removed the util.py module as well as some utilities from connections.py; vendor the small set of very short functions locally and open up requirements to support PyMySQL 1.0.0

