### PR TITLE
Fix MySQL 8.0 tests, properly close timed out connections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,8 @@ To be included in 1.0.0 (unreleased)
 * Don't send sys.argv[0] as program_name to MySQL server by default #620
 * Fix timed out MySQL 8.0 connections raising InternalError rather than OperationalError #660
 * Fix timed out MySQL 8.0 connections being returned from Pool #660
-* Ensure connections are properly closed before raising OperationalError when the server connection is lost #660
+* Ensure connections are properly closed before raising an OperationalError when the server connection is lost #660
+* Ensure connections are properly closed before raising an InternalError when packet sequence numbers are out of sync #660
 
 
 0.0.22 (2021-11-14)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ To be included in 1.0.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Don't send sys.argv[0] as program_name to MySQL server by default #620
+* Fix timed out MySQL 8.0 connections raising InternalError rather than OperationalError #660
+* Fix timed out MySQL 8.0 connections being returned from Pool #660
+* Ensure connections are properly closed before raising OperationalError when the server connection is lost #660
 
 
 0.0.22 (2021-11-14)

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -619,9 +619,9 @@ class Connection:
             # we increment in both write_packet and read_packet. The count
             # is reset at new COMMAND PHASE.
             if packet_number != self._next_seq_id:
+                self.close()
                 if packet_number == 0:
                     # MySQL 8.0 sends error packet with seqno==0 when shutdown
-                    self.close()
                     raise OperationalError(
                         CR.CR_SERVER_LOST,
                         "Lost connection to MySQL server during query")

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -143,12 +143,17 @@ class Pool(asyncio.AbstractServer):
                     await self._cond.wait()
 
     async def _fill_free_pool(self, override_min):
-        # iterate over free connections and remove timeouted ones
+        # iterate over free connections and remove timed out ones
         free_size = len(self._free)
         n = 0
         while n < free_size:
             conn = self._free[-1]
             if conn._reader.at_eof() or conn._reader.exception():
+                self._free.pop()
+                conn.close()
+
+            # TODO: fixme, we should not use internal attributes
+            elif conn._reader._eof:
                 self._free.pop()
                 conn.close()
 

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -152,8 +152,9 @@ class Pool(asyncio.AbstractServer):
                 self._free.pop()
                 conn.close()
 
-            # TODO: fixme, we should not use internal attributes
-            elif conn._reader._eof:
+            # On MySQL 8.0 a timed out connection sends an error packet before
+            # closing the connection, preventing us from relying on at_eof().
+            elif conn._reader.eof_received:
                 self._free.pop()
                 conn.close()
 

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -154,6 +154,8 @@ class Pool(asyncio.AbstractServer):
 
             # On MySQL 8.0 a timed out connection sends an error packet before
             # closing the connection, preventing us from relying on at_eof().
+            # This relies on our custom StreamReader, as eof_received is not
+            # present in asyncio.StreamReader.
             elif conn._reader.eof_received:
                 self._free.pop()
                 conn.close()


### PR DESCRIPTION
## What do these changes do?

Currently tests on timed out connections fail on MySQL 8.0.

This ports https://github.com/PyMySQL/PyMySQL/pull/540.
Interestingly, the PyMySQL issue originally referred to MariaDB, however, I don't see this behavior on currently supported MariaDB versions.
MySQL 8.0 does behave this way though.

In addition to porting the connection related changes, due to us having a pool, we will also need to adjust the pool logic.
Currently the connection pool attempts to not return closed connections in `Pool.acquire` via `Pool._fill_free_pool`.
At this time the connection is not yet considered closed, that will only be determined on the next `Connection._read_packet`.

When MySQL 8.0 closes the connection on us e.g. due to a timeout, the connection will still have the packet containing the error message as a pending read. The TCP connection stays in `CLOSE_WAIT` state for this.
Having received EOF on the connection it isn't useful to us anymore, so while we may have data pending to be read we don't care about it.
There shouldn't be a case where we expect data available to be read here.

Unfortunately I was not able to find a public API that would provide this information on the connection opened by [`asyncio.open_connection()`](https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.open_connection), using internal attributes it is possible to read [`StreamReader._eof`](https://github.com/python/cpython/blob/6f9ca53a6ac343a5663cc5c52546acf9a63b605a/Lib/asyncio/streams.py#L392).

To avoid accessing this internal attribute I've added a custom `StreamReader` that will expose whether `reader.feed_eof()` was called, which the `Pool` can then rely on.
This is logically exposing the same information that would otherwise be available as `StreamReader._eof`.

I was not yet able to properly this against unix socket connections.
On minimal local testing using the 2 previously failing test cases the same behavior shows on unix sockets and is also resolved with the same custom `StreamReader`.
#664 should be implemented before the next release though to ensure we don't have any other unexpected issues on unix sockets.

After doing my own port I also realized that we already have a pending PR to port this (#358) since end of 2018.
While #358 also ports the same PyMySQL patch it does not account for closed connections in the pool, especially as the closed connection state is only discovered the next time the connection is accessed.
That may however be due to the issue being reported (in #340) for MariaDB 10.2 back then and the tests only covering MariaDB up to 10.1.

It may still be worth to migrate and merge the test cases from #358 though.

## Are there changes in behavior for the user?

Users accessing timed out MySQL 8.0 connections may previously have received `pymysql.err.InternalError` instead of an `pymysql.err.OperationalError`, this is now fixed.

Users retrieving MySQL 8.0 connections from a pool will no longer receive timed out connections.

Connections are now properly closed before raising a `pymysql.err.OperationalError` due to losing connection to the server.

Connections are now properly closed before raising a `pymysql.err.InternalError` when packet sequence numbers are out of sync.

## Related issue number

May fix #340, may fix #614

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into `CHANGES.txt`