### PR TITLE
remove deprecated asyncio.coroutines syntax from tests

### DIFF
--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -1,21 +1,6 @@
 import asyncio
 import unittest
 
-from functools import wraps
-
-
-def run_until_complete(fun):
-    if not asyncio.iscoroutinefunction(fun):
-        fun = asyncio.coroutine(fun)
-
-    @wraps(fun)
-    def wrapper(test, *args, **kw):
-        loop = test.loop
-        ret = loop.run_until_complete(
-            asyncio.wait_for(fun(test, *args, **kw), 15))
-        return ret
-    return wrapper
-
 
 class BaseTest(unittest.TestCase):
     """Base test case for unittests.

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import aiomysql
 from tests._testutils import BaseTest
@@ -6,24 +5,23 @@ from tests._testutils import BaseTest
 
 class AIOPyMySQLTestCase(BaseTest):
 
-    @asyncio.coroutine
-    def _connect_all(self):
-        conn1 = yield from aiomysql.connect(loop=self.loop, host=self.host,
-                                            port=self.port, user=self.user,
-                                            db=self.db,
-                                            password=self.password,
-                                            use_unicode=True, echo=True)
-        conn2 = yield from aiomysql.connect(loop=self.loop, host=self.host,
-                                            port=self.port, user=self.user,
-                                            db=self.other_db,
-                                            password=self.password,
-                                            use_unicode=False, echo=True)
-        conn3 = yield from aiomysql.connect(loop=self.loop, host=self.host,
-                                            port=self.port, user=self.user,
-                                            db=self.db,
-                                            password=self.password,
-                                            use_unicode=True, echo=True,
-                                            local_infile=True)
+    async def _connect_all(self):
+        conn1 = await aiomysql.connect(loop=self.loop, host=self.host,
+                                       port=self.port, user=self.user,
+                                       db=self.db,
+                                       password=self.password,
+                                       use_unicode=True, echo=True)
+        conn2 = await aiomysql.connect(loop=self.loop, host=self.host,
+                                       port=self.port, user=self.user,
+                                       db=self.other_db,
+                                       password=self.password,
+                                       use_unicode=False, echo=True)
+        conn3 = await aiomysql.connect(loop=self.loop, host=self.host,
+                                       port=self.port, user=self.user,
+                                       db=self.db,
+                                       password=self.password,
+                                       use_unicode=True, echo=True,
+                                       local_infile=True)
 
         self.connections = [conn1, conn2, conn3]
 
@@ -45,9 +43,9 @@ class AIOPyMySQLTestCase(BaseTest):
         self.doCleanups()
         super(AIOPyMySQLTestCase, self).tearDown()
 
-    @asyncio.coroutine
-    def connect(self, host=None, user=None, password=None,
-                db=None, use_unicode=True, no_delay=None, port=None, **kwargs):
+    async def connect(self, host=None, user=None, password=None,
+                      db=None, use_unicode=True, no_delay=None, port=None,
+                      **kwargs):
         if host is None:
             host = self.host
         if user is None:
@@ -58,18 +56,17 @@ class AIOPyMySQLTestCase(BaseTest):
             db = self.db
         if port is None:
             port = self.port
-        conn = yield from aiomysql.connect(loop=self.loop, host=host,
-                                           user=user, password=password,
-                                           db=db, use_unicode=use_unicode,
-                                           no_delay=no_delay, port=port,
-                                           **kwargs)
+        conn = await aiomysql.connect(loop=self.loop, host=host,
+                                      user=user, password=password,
+                                      db=db, use_unicode=use_unicode,
+                                      no_delay=no_delay, port=port,
+                                      **kwargs)
         self.addCleanup(conn.close)
         return conn
 
-    @asyncio.coroutine
-    def create_pool(self, host=None, user=None, password=None,
-                    db=None, use_unicode=True, no_delay=None,
-                    port=None, **kwargs):
+    async def create_pool(self, host=None, user=None, password=None,
+                          db=None, use_unicode=True, no_delay=None,
+                          port=None, **kwargs):
         if host is None:
             host = self.host
         if user is None:
@@ -80,10 +77,10 @@ class AIOPyMySQLTestCase(BaseTest):
             db = self.db
         if port is None:
             port = self.port
-        pool = yield from aiomysql.create_pool(loop=self.loop, host=host,
-                                               user=user, password=password,
-                                               db=db, use_unicode=use_unicode,
-                                               no_delay=no_delay, port=port,
-                                               **kwargs)
+        pool = await aiomysql.create_pool(loop=self.loop, host=host,
+                                          user=user, password=password,
+                                          db=db, use_unicode=use_unicode,
+                                          no_delay=no_delay, port=port,
+                                          **kwargs)
         self.addCleanup(pool.close)
         return pool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,10 +112,8 @@ def mysql_params(mysql_server):
 
 
 # TODO: fix this workaround
-@asyncio.coroutine
-def _cursor_wrapper(conn):
-    cur = yield from conn.cursor()
-    return cur
+async def _cursor_wrapper(conn):
+    return await conn.cursor()
 
 
 @pytest.fixture
@@ -137,12 +135,11 @@ def connection(mysql_params, loop):
 def connection_creator(mysql_params, loop):
     connections = []
 
-    @asyncio.coroutine
-    def f(**kw):
+    async def f(**kw):
         conn_kw = mysql_params.copy()
         conn_kw.update(kw)
         _loop = conn_kw.pop('loop', loop)
-        conn = yield from aiomysql.connect(loop=_loop, **conn_kw)
+        conn = await aiomysql.connect(loop=_loop, **conn_kw)
         connections.append(conn)
         return conn
 
@@ -159,12 +156,11 @@ def connection_creator(mysql_params, loop):
 def pool_creator(mysql_params, loop):
     pools = []
 
-    @asyncio.coroutine
-    def f(**kw):
+    async def f(**kw):
         conn_kw = mysql_params.copy()
         conn_kw.update(kw)
         _loop = conn_kw.pop('loop', loop)
-        pool = yield from aiomysql.create_pool(loop=_loop, **conn_kw)
+        pool = await aiomysql.create_pool(loop=_loop, **conn_kw)
         pools.append(pool)
         return pool
 


### PR DESCRIPTION
## What do these changes do?

Remove legacy async syntax from tests, as this is not needed anymore for any currently supported python version.
`tests._testutils.run_until_complete` is not referenced anymore since moving to `pytest.mark.run_loop` in 819d4ec5fb967a679cad134eba885a1ce4bb5cee, therefore removed.

## Are there changes in behavior for the user?

No.

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into `CHANGES.txt` folder