### PR TITLE
Don't send sys.argv[0] as program_name to MySQL server by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changes
 -------
 
+To be included in 1.0.0 (unreleased)
+^^^^^^^^^^^^^^^^^^^
+
+* Don't send sys.argv[0] as program_name to MySQL server by default #620
+
+
 0.0.22 (2021-11-14)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -131,7 +131,7 @@ class Connection:
             when using IAM authentication with Amazon RDS.
             (default: Server Default)
         :param program_name: Program name string to provide when
-            handshaking with MySQL. (default: sys.argv[0])
+            handshaking with MySQL. (omitted by default)
         :param server_public_key: SHA256 authentication plugin public
             key value.
         :param loop: asyncio loop
@@ -185,8 +185,6 @@ class Connection:
         }
         if program_name:
             self._connect_attrs["program_name"] = program_name
-        elif sys.argv:
-            self._connect_attrs["program_name"] = sys.argv[0]
 
         self._unix_socket = unix_socket
         if charset:

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -88,7 +88,9 @@ Example::
         when using IAM authentication with Amazon RDS.
         (default: Server Default)
     :param program_name: Program name string to provide when
-        handshaking with MySQL. (default: sys.argv[0])
+        handshaking with MySQL. (omitted by default)
+      .. versionchanged:: 1.0
+         ``sys.argv[0]`` is no longer passed by default
     :param server_public_key: SHA256 authenticaiton plugin public key value.
     :param loop: asyncio event loop instance or ``None`` for default one.
     :returns: :class:`Connection` instance.


### PR DESCRIPTION
## What do these changes do?

This ports PyMySQL's change: https://github.com/PyMySQL/PyMySQL/pull/755

## Are there changes in behavior for the user?

We no longer implicitly send `sys.argv[0]` to the DB server by default.
For the majority of users this should not be relevant, if you need this value you can still pass it explicitly.

## Related issue number

fixes #620, closes #621

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`