### PR TITLE
fix formatting in documentation after #681

### DIFF
--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -89,8 +89,9 @@ Example::
         (default: Server Default)
     :param program_name: Program name string to provide when
         handshaking with MySQL. (omitted by default)
-      .. versionchanged:: 1.0
-         ``sys.argv[0]`` is no longer passed by default
+
+        .. versionchanged:: 1.0
+            ``sys.argv[0]`` is no longer passed by default
     :param server_public_key: SHA256 authenticaiton plugin public key value.
     :param loop: asyncio event loop instance or ``None`` for default one.
     :returns: :class:`Connection` instance.


### PR DESCRIPTION
## What do these changes do?

Fix docs formatting.

We should adjust the local docs generation to use the RTD theme, that will make it easier to spot this in the future.

## Are there changes in behavior for the user?

no.

## Related issue number

#681

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment to `CHANGES.txt`