### PR TITLE
move pyroma to lint ci workflow, fail if rating is below 10/10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,6 @@ jobs:
       run: |
         python setup.py check --restructuredtext
 
-    - name: Run pyroma
-      run: |
-        python -m pyroma -d .
-
     # this ensures our database is ready. typically by the time the preparations have completed its first start logic.
     # unfortunately we need this hacky workaround as GitHub Actions service containers can't reference data from our repo.
     - name: Prepare mysql

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,14 @@ jobs:
           key: pip-lint
           path: ${{ steps.pip-cache.outputs.dir }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade --requirement requirements-dev.txt
+
+      - name: Run pyroma
+        run: |
+          python -m pyroma --min 10 --directory .
+
       - name: flake8 Lint
         uses: py-actions/flake8@v2.0.0
         with:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@ Changes
 -------
 
 To be included in 1.0.0 (unreleased)
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Don't send sys.argv[0] as program_name to MySQL server by default #620
 


### PR DESCRIPTION
## What do these changes do?

Fail Lint workflow when pyroma rating is not 10/10.
Unless this is implemented the pyroma action doesn't do much, as it's easily missed when not explicitly looking at the step output.

## Are there changes in behavior for the user?

no