### PR TITLE
parameterize mysql_address in tests, allow passing one or more addresses via pytest args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         # timeout ensures a more or less clean stop by sending a KeyboardInterrupt which will still provide useful logs
         timeout --preserve-status --signal=INT --verbose 5m \
-          pytest --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov aiomysql ./tests
+          pytest --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov aiomysql ./tests --mysql-address "tcp-${{ join(matrix.db, '') }}=127.0.0.1:3306"
       env:
         PYTHONUNBUFFERED: 1
         DB: '${{ matrix.db[0] }}'


### PR DESCRIPTION
## What do these changes do?

Second set of changes split from #686.

This allows passing a mysql address via pytest argument, preparing for being able to test more databases/database connections in the same pytest run.
An unfortunate side effect of this currently is that pytest now no longer groups the tests with different event loop implementations.
I haven't dug into pytest too much yet to figure out if that can be solved, but this is mostly just a cosmetic/convenience difference.