### PR TITLE
ensure test_scroll_errors and test_sscursor_scroll_errors initialize their tables

### DIFF
--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -94,6 +94,7 @@ async def test_scroll_absolute(connection_creator):
 @pytest.mark.run_loop
 async def test_scroll_errors(connection_creator):
     conn = await connection_creator()
+    await _prepare(conn)
     cur = await conn.cursor()
 
     with pytest.raises(ProgrammingError):

--- a/tests/test_sscursor.py
+++ b/tests/test_sscursor.py
@@ -132,6 +132,7 @@ async def test_sscursor_scroll_absolute(connection):
 @pytest.mark.run_loop
 async def test_sscursor_scroll_errors(connection):
     conn = connection
+    await _prepare(conn)
     cursor = await conn.cursor(SSCursor)
 
     await cursor.execute('SELECT * FROM tz_data;')
@@ -151,7 +152,7 @@ async def test_sscursor_scroll_errors(connection):
 async def test_sscursor_cancel(connection):
     conn = connection
     cur = await conn.cursor(SSCursor)
-    # Prepare ALOT of data
+    # Prepare A LOT of data
 
     await cur.execute('DROP TABLE IF EXISTS long_seq;')
     await cur.execute(


### PR DESCRIPTION
## What do these changes do?

When changing the order of some tests, e.g. not running asyncio and uvloop tests next to each other, these missing prepares can currently lead to test failures.
This failed e.g. in #693.
I have not yet checked why this wouldn't always fail, as it seems that sometimes these tables are available, but this fixes the tests to only rely on data expected to be present.