### PR TITLE
implement a shortcut for determining secure connections, now supporting unix sockets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ To be included in 1.0.0 (unreleased)
 * Fix timed out MySQL 8.0 connections being returned from Pool #660
 * Ensure connections are properly closed before raising an OperationalError when the server connection is lost #660
 * Ensure connections are properly closed before raising an InternalError when packet sequence numbers are out of sync #660
+* Unix sockets are now internally considered secure, allowing sha256_password and caching_sha2_password auth methods to be used #695
 
 
 0.0.22 (2021-11-14)


### PR DESCRIPTION
## What do these changes do?

implement a shortcut for determining secure connections, now supporting unix sockets
ports https://github.com/PyMySQL/PyMySQL/pull/696
ports check for server tls support for secure connections from https://github.com/PyMySQL/PyMySQL/pull/353

Unix sockets are now internally considered secure.

## Are there changes in behavior for the user?

`sha256_password` and `caching_sha2_password` should now work for unix sockets (pending tests from #686)

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`