### PR TITLE
ensure coroutine is awaited when discarding results in SSCursor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ To be included in 1.0.0 (unreleased)
 * Ensure connections are properly closed before raising an InternalError when packet sequence numbers are out of sync #660
 * Unix sockets are now internally considered secure, allowing sha256_password and caching_sha2_password auth methods to be used #695
 * Test suite now also tests unix socket connections #696
+* Fix SSCursor raising InternalError when last result was not fully retrieved #635
 
 
 0.0.22 (2021-11-14)

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -711,7 +711,7 @@ class Connection:
         if self._result is not None:
             if self._result.unbuffered_active:
                 warnings.warn("Previous unbuffered result was left incomplete")
-                self._result._finish_unbuffered_query()
+                await self._result._finish_unbuffered_query()
             while self._result.has_next:
                 await self.next_result()
             self._result = None

--- a/tests/test_sscursor.py
+++ b/tests/test_sscursor.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from pymysql import NotSupportedError, InternalError
+from pymysql import NotSupportedError
 
 from aiomysql import ProgrammingError, InterfaceError
 from aiomysql.cursors import SSCursor
@@ -190,11 +190,6 @@ async def test_sscursor_cancel(connection):
         await conn.cursor(SSCursor)
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/aio-libs/aiomysql/issues/635",
-    raises=InternalError,
-    strict=True,
-)
 @pytest.mark.run_loop
 async def test_sscursor_discarded_result(connection):
     conn = connection
@@ -203,4 +198,4 @@ async def test_sscursor_discarded_result(connection):
         await cursor.execute("select 1")
         await cursor.execute("select 2")
         ret = await cursor.fetchone()
-    assert (1,) == ret
+    assert (2,) == ret


### PR DESCRIPTION
## What do these changes do?

Awaits coroutine that was missed in #52.
Also fixes related test case.

## Are there changes in behavior for the user?

SSCursor no longer raises an `InternalError` when the previous cursor was not properly 

## Related issue number

Fixes #635

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`