### PR TITLE
remove deprecated no_delay argument

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ To be included in 1.0.0 (unreleased)
 * Unix sockets are now internally considered secure, allowing sha256_password and caching_sha2_password auth methods to be used #695
 * Test suite now also tests unix socket connections #696
 * Fix SSCursor raising InternalError when last result was not fully retrieved #635
+* Remove deprecated no_delay argument #702
 
 
 0.0.22 (2021-11-14)

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -55,7 +55,7 @@ def connect(host="localhost", user=None, password="",
             read_default_file=None, conv=decoders, use_unicode=None,
             client_flag=0, cursorclass=Cursor, init_command=None,
             connect_timeout=None, read_default_group=None,
-            no_delay=None, autocommit=False, echo=False,
+            autocommit=False, echo=False,
             local_infile=False, loop=None, ssl=None, auth_plugin='',
             program_name='', server_public_key=None):
     """See connections.Connection.__init__() for information about
@@ -68,7 +68,7 @@ def connect(host="localhost", user=None, password="",
                     init_command=init_command,
                     connect_timeout=connect_timeout,
                     read_default_group=read_default_group,
-                    no_delay=no_delay, autocommit=autocommit, echo=echo,
+                    autocommit=autocommit, echo=echo,
                     local_infile=local_infile, loop=loop, ssl=ssl,
                     auth_plugin=auth_plugin, program_name=program_name)
     return _ConnectionContextManager(coro)
@@ -144,7 +144,7 @@ class Connection:
                  read_default_file=None, conv=decoders, use_unicode=None,
                  client_flag=0, cursorclass=Cursor, init_command=None,
                  connect_timeout=None, read_default_group=None,
-                 no_delay=None, autocommit=False, echo=False,
+                 autocommit=False, echo=False,
                  local_infile=False, loop=None, ssl=None, auth_plugin='',
                  program_name='', server_public_key=None):
         """
@@ -175,7 +175,6 @@ class Connection:
             when connecting.
         :param read_default_group: Group to read from in the configuration
             file.
-        :param no_delay: Disable Nagle's algorithm on the socket
         :param autocommit: Autocommit mode. None means use server default.
             (default: False)
         :param local_infile: boolean to enable the use of LOAD DATA LOCAL
@@ -211,19 +210,11 @@ class Connection:
             port = int(_config("port", fallback=port))
             charset = _config("default-character-set", fallback=charset)
 
-        # pymysql port
-        if no_delay is not None:
-            warnings.warn("no_delay option is deprecated", DeprecationWarning)
-            no_delay = bool(no_delay)
-        else:
-            no_delay = True
-
         self._host = host
         self._port = port
         self._user = user or DEFAULT_USER
         self._password = password or ""
         self._db = db
-        self._no_delay = no_delay
         self._echo = echo
         self._last_usage = self._loop.time()
         self._client_auth_plugin = auth_plugin
@@ -544,11 +535,8 @@ class Connection:
                             self._port),
                         timeout=self.connect_timeout)
                 self._set_keep_alive()
-                self.host_info = "socket %s:%d" % (self._host, self._port)
-
-            # do not set no delay in case of unix_socket
-            if self._no_delay and not self._unix_socket:
                 self._set_nodelay(True)
+                self.host_info = "socket %s:%d" % (self._host, self._port)
 
             self._next_seq_id = 0
 

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -45,7 +45,7 @@ Example::
             read_default_file=None, conv=decoders, use_unicode=None,
             client_flag=0, cursorclass=Cursor, init_command=None,
             connect_timeout=None, read_default_group=None,
-            no_delay=False, autocommit=False, echo=False,
+            autocommit=False, echo=False
             ssl=None, auth_plugin='', program_name='',
             server_public_key=None, loop=None)
 
@@ -79,7 +79,6 @@ Example::
         when connecting.
     :param str read_default_group: Group to read from in the configuration
         file.
-    :param bool no_delay: disable Nagle's algorithm on the socket
     :param autocommit: Autocommit mode. None means use server default.
         (default: ``False``)
     :param ssl: Optional SSL Context to force SSL

--- a/tests/base.py
+++ b/tests/base.py
@@ -44,7 +44,7 @@ class AIOPyMySQLTestCase(BaseTest):
         super(AIOPyMySQLTestCase, self).tearDown()
 
     async def connect(self, host=None, user=None, password=None,
-                      db=None, use_unicode=True, no_delay=None, port=None,
+                      db=None, use_unicode=True, port=None,
                       **kwargs):
         if host is None:
             host = self.host
@@ -59,13 +59,13 @@ class AIOPyMySQLTestCase(BaseTest):
         conn = await aiomysql.connect(loop=self.loop, host=host,
                                       user=user, password=password,
                                       db=db, use_unicode=use_unicode,
-                                      no_delay=no_delay, port=port,
+                                      port=port,
                                       **kwargs)
         self.addCleanup(conn.close)
         return conn
 
     async def create_pool(self, host=None, user=None, password=None,
-                          db=None, use_unicode=True, no_delay=None,
+                          db=None, use_unicode=True,
                           port=None, **kwargs):
         if host is None:
             host = self.host
@@ -80,7 +80,7 @@ class AIOPyMySQLTestCase(BaseTest):
         pool = await aiomysql.create_pool(loop=self.loop, host=host,
                                           user=user, password=password,
                                           db=db, use_unicode=use_unicode,
-                                          no_delay=no_delay, port=port,
+                                          port=port,
                                           **kwargs)
         self.addCleanup(pool.close)
         return pool

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -243,20 +243,6 @@ async def test___del__(connection_creator):
 
 
 @pytest.mark.run_loop
-async def test_no_delay_warning(connection_creator):
-    with pytest.warns(DeprecationWarning):
-        conn = await connection_creator(no_delay=True)
-    conn.close()
-
-
-@pytest.mark.run_loop
-async def test_no_delay_default_arg(connection_creator):
-    conn = await connection_creator()
-    assert conn._no_delay is True
-    conn.close()
-
-
-@pytest.mark.run_loop
 async def test_previous_cursor_not_closed(connection_creator):
     conn = await connection_creator()
     cur1 = await conn.cursor()


### PR DESCRIPTION
## What do these changes do?

The deprecated `no_delay` argument is removed from `Connection`.

## Are there changes in behavior for the user?

`no_delay` may no longer be passed when a pool or connection is created.

## Related issue number

no

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`