### PR TITLE
add flake8 config, set max-line-length to 88

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
## What do these changes do?

allow lines of up to 88 characters.
this also provides compatibility with upcoming black formatting.

## Are there changes in behavior for the user?

no