### PR TITLE
remove deprecated Pool.get

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,9 +2,11 @@ Changes
 -------
 
 next (unreleased)
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 * Bump minimal SQLAlchemy version to 1.3 #815
+
+* Remove deprecated Pool.get #706
 
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -230,12 +230,6 @@ class Pool(asyncio.AbstractServer):
             fut = self._loop.create_task(self._wakeup())
         return fut
 
-    def get(self):
-        warnings.warn("pool.get deprecated use pool.acquire instead",
-                      DeprecationWarning,
-                      stacklevel=2)
-        return _PoolConnectionContextManager(self, None)
-
     def __enter__(self):
         raise RuntimeError(
             '"yield from" should be used as context manager expression')

--- a/examples/example_ssl.py
+++ b/examples/example_ssl.py
@@ -13,7 +13,7 @@ async def main():
             password='rootpw', ssl=ctx,
             auth_plugin='mysql_clear_password') as pool:
 
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             async with conn.cursor() as cur:
                 # Run simple command
                 await cur.execute("SHOW DATABASES;")

--- a/tests/test_async_with.py
+++ b/tests/test_async_with.py
@@ -129,18 +129,6 @@ async def test_create_pool_deprecations(mysql_params, loop):
     async with create_pool(loop=loop, **mysql_params) as pool:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            async with pool.get() as conn:
-                pass
-    # The first warning emitted is expected to be DeprecationWarning:
-    # in the past, we used to check for the last one but this assumption
-    # breaks under Python 3.7 that also emits a `ResourceWarning` when
-    # executed with `PYTHONASYNCIODEBUG=1`.
-    assert issubclass(w[0].category, DeprecationWarning)
-    assert conn.closed
-
-    async with create_pool(loop=loop, **mysql_params) as pool:
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
             with await pool as conn:
                 pass
     assert issubclass(w[-1].category, DeprecationWarning)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -427,7 +427,7 @@ async def test_issue_175(connection):
 async def test_issue_323(mysql_server, loop, recwarn):
     async with aiomysql.create_pool(**mysql_server['conn_params'],
                                     loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             async with conn.cursor() as cur:
                 drop_db = "DROP DATABASE IF EXISTS bugtest;"
                 await cur.execute(drop_db)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -79,7 +79,7 @@ async def test_bad_context_manager_usage(pool_creator):
 @pytest.mark.run_loop
 async def test_context_manager(pool_creator):
     pool = await pool_creator(minsize=10, maxsize=10)
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         assert isinstance(conn, Connection)
         assert 9 == pool.freesize
         assert {conn} == pool._used
@@ -101,7 +101,7 @@ async def test_initial_empty(pool_creator):
     assert 0 == pool.size
     assert 0 == pool.freesize
 
-    async with pool.get():
+    async with pool.acquire():
         assert 1 == pool.size
         assert 0 == pool.freesize
     assert 1 == pool.size
@@ -236,7 +236,7 @@ async def test_release_with_invalid_status_wait_release(pool_creator):
 @pytest.mark.run_loop
 async def test__fill_free(pool_creator, loop):
     pool = await pool_creator(minsize=1)
-    async with pool.get():
+    async with pool.acquire():
         assert 0 == pool.freesize
         assert 1 == pool.size
 
@@ -256,7 +256,7 @@ async def test_connect_from_acquire(pool_creator):
     pool = await pool_creator(minsize=0)
     assert 0 == pool.freesize
     assert 0 == pool.size
-    async with pool.get():
+    async with pool.acquire():
         assert 1 == pool.size
         assert 0 == pool.freesize
     assert 1 == pool.size
@@ -353,7 +353,7 @@ async def test_echo(pool_creator):
     pool = await pool_creator(echo=True)
     assert pool.echo
 
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         assert conn.echo
 
 
@@ -482,7 +482,7 @@ async def test_cancelled_connection(pool_creator, loop):
     pool = await pool_creator(minsize=0, maxsize=1)
 
     try:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             curs = await conn.cursor()
             # Cancel a cursor in the middle of execution, before it
             # could read even the first packet (SLEEP assures the
@@ -495,7 +495,7 @@ async def test_cancelled_connection(pool_creator, loop):
     except asyncio.CancelledError:
         pass
 
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         cur2 = await conn.cursor()
         res = await cur2.execute("SELECT 2 as value, 0 as xxx")
         names = [x[0] for x in cur2.description]
@@ -509,7 +509,7 @@ async def test_cancelled_connection(pool_creator, loop):
 @pytest.mark.run_loop
 async def test_pool_with_connection_recycling(pool_creator, loop):
     pool = await pool_creator(minsize=1, maxsize=1, pool_recycle=3)
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         cur = await conn.cursor()
         await cur.execute('SELECT 1;')
         val = await cur.fetchone()
@@ -518,7 +518,7 @@ async def test_pool_with_connection_recycling(pool_creator, loop):
     await asyncio.sleep(5)
 
     assert 1 == pool.freesize
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         cur = await conn.cursor()
         await cur.execute('SELECT 1;')
         val = await cur.fetchone()
@@ -529,14 +529,14 @@ async def test_pool_with_connection_recycling(pool_creator, loop):
 async def test_pool_drops_connection_with_exception(pool_creator, loop):
     pool = await pool_creator(minsize=1, maxsize=1)
 
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         cur = await conn.cursor()
         await cur.execute('SELECT 1;')
 
     connection, = pool._free
     connection._writer._protocol.connection_lost(IOError())
 
-    async with pool.get() as conn:
+    async with pool.acquire() as conn:
         cur = await conn.cursor()
         await cur.execute('SELECT 1;')
 

--- a/tests/test_sha_connection.py
+++ b/tests/test_sha_connection.py
@@ -39,7 +39,7 @@ async def test_sha256_nopw(mysql_server, loop):
 
     async with create_pool(**connection_data,
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             # User doesnt have any permissions to look at DBs
             # But as 8.0 will default to caching_sha2_password
             assert conn._auth_plugin_used == 'sha256_password'
@@ -62,7 +62,7 @@ async def test_sha256_pw(mysql_server, loop):
 
     async with create_pool(**connection_data,
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             # User doesnt have any permissions to look at DBs
             # But as 8.0 will default to caching_sha2_password
             assert conn._auth_plugin_used == 'sha256_password'
@@ -78,7 +78,7 @@ async def test_cached_sha256_nopw(mysql_server, loop):
 
     async with create_pool(**connection_data,
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             # User doesnt have any permissions to look at DBs
             # But as 8.0 will default to caching_sha2_password
             assert conn._auth_plugin_used == 'caching_sha2_password'
@@ -94,7 +94,7 @@ async def test_cached_sha256_pw(mysql_server, loop):
 
     async with create_pool(**connection_data,
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             # User doesnt have any permissions to look at DBs
             # But as 8.0 will default to caching_sha2_password
             assert conn._auth_plugin_used == 'caching_sha2_password'

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -10,7 +10,7 @@ async def test_tls_connect(mysql_server, loop, mysql_params):
 
     async with create_pool(**mysql_server['conn_params'],
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             async with conn.cursor() as cur:
                 # Run simple command
                 await cur.execute("SHOW DATABASES;")
@@ -42,7 +42,7 @@ async def test_auth_plugin_renegotiation(mysql_server, loop, mysql_params):
     async with create_pool(**mysql_server['conn_params'],
                            auth_plugin='mysql_clear_password',
                            loop=loop) as pool:
-        async with pool.get() as conn:
+        async with pool.acquire() as conn:
             async with conn.cursor() as cur:
                 # Run simple command
                 await cur.execute("SHOW DATABASES;")


### PR DESCRIPTION
## What do these changes do?

Deprecated method `Pool.get` was removed

## Are there changes in behavior for the user?

Yes, see above.

## Related issue number

no

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`