### PR TITLE
automatically detect db type and version in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,6 @@ jobs:
           pytest --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov aiomysql --cov tests ./tests --mysql-unix-socket "unix-${{ join(matrix.db, '') }}=/tmp/run-${{ join(matrix.db, '-') }}/mysql.sock" --mysql-address "tcp-${{ join(matrix.db, '') }}=127.0.0.1:3306"
       env:
         PYTHONUNBUFFERED: 1
-        DB: '${{ matrix.db[0] }}'
-        DBTAG: '${{ matrix.db[1] }}'
       timeout-minutes: 6
 
     - name: Upload coverage

--- a/tests/test_sha_connection.py
+++ b/tests/test_sha_connection.py
@@ -21,9 +21,18 @@ import pytest
 # ])
 
 
-@pytest.mark.mysql_version('mysql', '8.0')
+def ensure_mysql_version(mysql_server):
+    if mysql_server["db_type"] != "mysql" \
+            or mysql_server["server_version_tuple_short"] != (8, 0):
+        pytest.skip("Not applicable for {0} version: {1}"
+                    .format(mysql_server["db_type"],
+                            mysql_server["server_version_tuple_short"]))
+
+
 @pytest.mark.run_loop
 async def test_sha256_nopw(mysql_server, loop):
+    ensure_mysql_version(mysql_server)
+
     connection_data = copy.copy(mysql_server['conn_params'])
     connection_data['user'] = 'nopass_sha256'
     connection_data['password'] = None
@@ -36,9 +45,10 @@ async def test_sha256_nopw(mysql_server, loop):
             assert conn._auth_plugin_used == 'sha256_password'
 
 
-@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_sha256_pw(mysql_server, loop):
+    ensure_mysql_version(mysql_server)
+
     # https://dev.mysql.com/doc/refman/8.0/en/sha256-pluggable-authentication.html
     # Unlike caching_sha2_password, the sha256_password plugin does not treat
     # shared-memory connections as secure, even though share-memory transport
@@ -58,9 +68,10 @@ async def test_sha256_pw(mysql_server, loop):
             assert conn._auth_plugin_used == 'sha256_password'
 
 
-@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_cached_sha256_nopw(mysql_server, loop):
+    ensure_mysql_version(mysql_server)
+
     connection_data = copy.copy(mysql_server['conn_params'])
     connection_data['user'] = 'nopass_caching_sha2'
     connection_data['password'] = None
@@ -73,9 +84,10 @@ async def test_cached_sha256_nopw(mysql_server, loop):
             assert conn._auth_plugin_used == 'caching_sha2_password'
 
 
-@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_cached_sha256_pw(mysql_server, loop):
+    ensure_mysql_version(mysql_server)
+
     connection_data = copy.copy(mysql_server['conn_params'])
     connection_data['user'] = 'user_caching_sha2'
     connection_data['password'] = 'pass_caching_sha2'


### PR DESCRIPTION
## What do these changes do?

automatically detect db type and version in tests

this removes the need to pass the db type and version from environment variables.
it also makes it possible to pass connections to different databases to the same pytest run.

due to the version detection now relying on the parameterized mysql_address fixture
it is no longer compatible with tests independent from the connection, especially
relevant in test_sa_distil.py.
to resolve this the version gate was moved directly into test_sha_connection.py.

## Are there changes in behavior for the user?

no

## Related issue number

no

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment to the `CHANGES.txt`