### PR TITLE
bump minimal PyMySQL version to 1.0.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ To be included in 1.0.0 (unreleased)
 * Fix SSCursor raising InternalError when last result was not fully retrieved #635
 * Remove deprecated no_delay argument #702
 * Support PyMySQL up to version 1.0.2 #643
+* Bump minimal PyMySQL version to 1.0.0 #713
 
 
 0.0.22 (2021-11-14)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ ipdb==0.13.9
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-sugar==0.9.4
-PyMySQL>=0.9,<=1.0.2
+PyMySQL>=1.0.0,<=1.0.2
 sphinx>=1.8.1, <4.4.1
 sphinxcontrib-asyncio==0.3.0
 sqlalchemy>1.2.12,<=1.3.16

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-install_requires = ['PyMySQL>=0.9,<=1.0.2']
+install_requires = ['PyMySQL>=1.0.0,<=1.0.2']
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
## What do these changes do?

while we do not yet strictly require it this simplifies maintenance.
e.g. the xfailing test from #712 gets a different error type starting with PyMySQL 0.10.0.
it will also allow us to adopt the backwards incompatible changes from PyMySQL 0.10 and 1.0.
as our test suite only runs with the latest supported PyMySQL version we currently cannot
reliably test older versions either.

## Are there changes in behavior for the user?

PyMySQL <1.0 is no longer supported.

## Related issue number

Fixes #518

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`