### PR TITLE
Align % formatting in Cursor.executemany() with Cursor.execute()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,7 @@ To be included in 1.0.0 (unreleased)
 * Remove deprecated no_delay argument #702
 * Support PyMySQL up to version 1.0.2 #643
 * Bump minimal PyMySQL version to 1.0.0 #713
+* Align % formatting in Cursor.executemany() with Cursor.execute(), literal % now need to be doubled in Cursor.executemany() #714
 
 
 0.0.22 (2021-11-14)

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -14,7 +14,7 @@ from .connection import FIELD_TYPE
 # https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/cursors.py#L11-L18
 
 #: Regular expression for :meth:`Cursor.executemany`.
-#: executemany only suports simple bulk insert.
+#: executemany only supports simple bulk insert.
 #: You can use it to load large dataset.
 RE_INSERT_VALUES = re.compile(
     r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
@@ -274,7 +274,7 @@ class Cursor:
 
         m = RE_INSERT_VALUES.match(query)
         if m:
-            q_prefix = m.group(1)
+            q_prefix = m.group(1) % ()
             q_values = m.group(2).rstrip()
             q_postfix = m.group(3) or ''
             assert q_values[0] == '(' and q_values[-1] == ')'

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -2,8 +2,6 @@ import asyncio
 
 import pytest
 
-from pymysql.err import OperationalError
-
 from aiomysql import ProgrammingError, Cursor, InterfaceError
 from aiomysql.cursors import RE_INSERT_VALUES
 
@@ -339,11 +337,6 @@ async def test_execute_percentage(connection_creator):
         await cur.execute(q, (3, 4))
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/aio-libs/aiomysql/pull/545",
-    raises=OperationalError,
-    strict=True,
-)
 @pytest.mark.run_loop
 async def test_executemany_percentage(connection_creator):
     # %% in column set
@@ -359,5 +352,5 @@ async def test_executemany_percentage(connection_creator):
 
         assert RE_INSERT_VALUES.match(q) is not None
         await cur.executemany(q, [(3, 4), (5, 6)])
-        assert cur._last_executed.endswith("(3, 4),(5, 6)"), \
+        assert cur._last_executed.endswith(b"(3, 4),(5, 6)"), \
             "executemany with %% not in one query"


### PR DESCRIPTION
## What do these changes do?

port the changes from https://github.com/PyMySQL/PyMySQL/pull/450

## Are there changes in behavior for the user?

`%%` is now required for literal `%` in `Cursor.executemany()`.
This aligns behavior with `Cursor.execute()`.

## Related issue number

closes #545

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`