### PR TITLE
add Pool.closed property as present in aiopg, fixes #463

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ To be included in 1.0.0 (unreleased)
 * Bump minimal PyMySQL version to 1.0.0 #713
 * Align % formatting in Cursor.executemany() with Cursor.execute(), literal % now need to be doubled in Cursor.executemany() #714
 * Fixed unlimited Pool size not working, this is now working as documented by passing maxsize=0 to create_pool #119
+* Added Pool.closed property as present in aiopg #463
 
 
 0.0.22 (2021-11-14)

--- a/aiomysql/pool.py
+++ b/aiomysql/pool.py
@@ -1,4 +1,4 @@
-# copied from aiopg
+# based on aiopg pool
 # https://github.com/aio-libs/aiopg/blob/master/aiopg/pool.py
 
 import asyncio
@@ -78,6 +78,13 @@ class Pool(asyncio.AbstractServer):
                 conn = self._free.popleft()
                 await conn.ensure_closed()
             self._cond.notify()
+
+    @property
+    def closed(self):
+        """
+        The readonly property that returns ``True`` if connections is closed.
+        """
+        return self._closed
 
     def close(self):
         """Close pool.

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -345,6 +345,7 @@ async def test_wait_closed(pool_creator, loop):
     await asyncio.gather(wait_closed(), do_release(c1), do_release(c2))
     assert ['release', 'release', 'wait_closed'] == ops
     assert 0 == pool.freesize
+    assert pool.closed
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
## What do these changes do?

New `closed` property for `Pool` instances, exposing whether the pool is closed.

## Are there changes in behavior for the user?

New property available.

## Related issue number

Fixes #463

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`