### PR TITLE
Move static setuptools config to setup.cfg

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,7 @@ To be included in 1.0.0 (unreleased)
 * Added Pool.closed property as present in aiopg #463
 * Fixed SQLAlchemy connection context iterator #410
 * Fix error packet handling for SSCursor #428
+* Required python version is now properly documented in python_requires instead of failing on setup.py execution #731
 
 
 0.0.22 (2021-11-14)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,41 @@
+[metadata]
+name = aiomysql
+url = https://github.com/aio-libs/aiomysql
+download_url = https://pypi.python.org/pypi/aiomysql
+description = MySQL driver for asyncio.
+author = Nikolay Novik
+author_email = nickolainovik@gmail.com
+classifiers =
+  License :: OSI Approved :: MIT License
+  Intended Audience :: Developers
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Operating System :: POSIX
+  Environment :: Web Environment
+  Development Status :: 3 - Alpha
+  Topic :: Database
+  Topic :: Database :: Front-Ends
+  Framework :: AsyncIO
+license = MIT
+keywords =
+  mysql
+  mariadb
+  asyncio
+  aiomysql
+platforms =
+  POSIX
+
+[options]
+python_requires = >=3.7
+include_package_data = True
+
+# runtime requirements
+install_requires =
+  PyMySQL>=1.0
+
+[options.extras_require]
+sa =
+  sqlalchemy>=1.0,<1.4

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,10 @@
 import os
 import re
-import sys
 from setuptools import setup, find_packages
-
-
-install_requires = ['PyMySQL>=1.0.0,<=1.0.2']
-
-PY_VER = sys.version_info
-
-
-if not PY_VER >= (3, 7, 0):
-    raise RuntimeError("aiomysql doesn't support Python earlier than 3.7.0")
 
 
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
-
-
-extras_require = {'sa': ['sqlalchemy>=1.0'], }
 
 
 def read_version():
@@ -33,38 +20,6 @@ def read_version():
             raise RuntimeError('Cannot find version in aiomysql/__init__.py')
 
 
-classifiers = [
-    'License :: OSI Approved :: MIT License',
-    'Intended Audience :: Developers',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Operating System :: POSIX',
-    'Environment :: Web Environment',
-    'Development Status :: 3 - Alpha',
-    'Topic :: Database',
-    'Topic :: Database :: Front-Ends',
-    'Framework :: AsyncIO',
-]
-
-keywords = ["mysql", "asyncio", "aiomysql"]
-
-
-setup(name='aiomysql',
-      version=read_version(),
-      description=('MySQL driver for asyncio.'),
+setup(version=read_version(),
       long_description='\n\n'.join((read('README.rst'), read('CHANGES.txt'))),
-      classifiers=classifiers,
-      platforms=['POSIX'],
-      author="Nikolay Novik",
-      author_email="nickolainovik@gmail.com",
-      url='https://github.com/aio-libs/aiomysql',
-      download_url='https://pypi.python.org/pypi/aiomysql',
-      license='MIT',
-      packages=find_packages(exclude=['tests', 'tests.*']),
-      install_requires=install_requires,
-      extras_require=extras_require,
-      keywords=keywords,
-      include_package_data=True)
+      packages=find_packages(exclude=['tests', 'tests.*']))


### PR DESCRIPTION
- implement `python_requires` to replace python version check during setup.py execution
- relax PyMySQL dependency to only pin minimum required version
- pin SQLAlchemy version to below 1.4, as 1.4 is currently not compatible
- add mariadb keyword