### PR TITLE
Add rsa extras_require depending on PyMySQL[rsa]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,7 @@ To be included in 1.0.0 (unreleased)
 * Fixed SQLAlchemy connection context iterator #410
 * Fix error packet handling for SSCursor #428
 * Required python version is now properly documented in python_requires instead of failing on setup.py execution #731
+* Add rsa extras_require depending on PyMySQL[rsa] #557
 
 
 0.0.22 (2021-11-14)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,5 @@ install_requires =
 [options.extras_require]
 sa =
   sqlalchemy>=1.0,<1.4
+rsa =
+  PyMySQL[rsa]>=1.0


### PR DESCRIPTION
## What do these changes do?

Allow installing `aiomysql[rsa]` to depend on the supported `PyMySQL[rsa]` version.

## Are there changes in behavior for the user?

no

## Related issue number

fixes #557

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`