### PR TITLE
Remove pyroma from tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,10 +41,6 @@ jobs:
         run: |
           python -m pip install --upgrade --requirement requirements-dev.txt
 
-      - name: Run pyroma
-        run: |
-          python -m pyroma --min 10 --directory .
-
       - name: flake8 Lint
         uses: py-actions/flake8@v2.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,8 @@ FLAGS=
 checkrst:
 	python setup.py check --restructuredtext
 
-pyroma:
-	pyroma -d .
 
-
-flake:checkrst pyroma
+flake:checkrst
 	flake8 aiomysql tests examples
 
 test: flake

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,3 @@ sphinx>=1.8.1, <4.4.1
 sphinxcontrib-asyncio==0.3.0
 sqlalchemy>1.2.12,<=1.3.24
 uvloop==0.16.0; python_version < '3.11'
-pyroma==3.2


### PR DESCRIPTION
## What do these changes do?

Removes pyroma from test suite, as this isn't compatible with the upcoming implementation of `setuptools-scm`.
https://github.com/regebro/pyroma/issues/69

## Are there changes in behavior for the user?

no

## Related issue number

split from #734

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment to `CHANGES.txt`