### PR TITLE
Pin exact runtime dependency versions for tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@ ipdb==0.13.9
 pytest==7.0.1
 pytest-cov==3.0.0
 pytest-sugar==0.9.4
-PyMySQL>=1.0.0,<=1.0.2
+PyMySQL==1.0.2
 sphinx>=1.8.1, <4.4.1
 sphinxcontrib-asyncio==0.3.0
-sqlalchemy>1.2.12,<=1.3.24
+SQLAlchemy==1.3.24
 uvloop==0.16.0; python_version < '3.11'


### PR DESCRIPTION
## What do these changes do?

Avoid automatically deciding which runtime dependency versions are tested against.

## Are there changes in behavior for the user?

no

## Related issue number

split from #734

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment to `CHANGES.txt`