### PR TITLE
Add readthedocs yaml config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false # FIXME
+
+formats:
+- pdf
+- epub
+
+python:
+   install:
+   - requirements: requirements-dev.txt


### PR DESCRIPTION
## What do these changes do?

Add `.readthedocs.yaml` to set build settings.

As docs builds currently emit warnings we can't treat them as errors just yet.

## Are there changes in behavior for the user?

no

## Related issue number

no

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into `CHANGES.txt`