### PR TITLE
fix `make checkrst`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 FLAGS=
 
 checkrst:
-	python setup.py check --restructuredtext
+	python -m twine check --strict dist/*
 
 
 flake:checkrst


### PR DESCRIPTION
## What do these changes do?

fix `make checkrst` to use `twine check` rather than `setup.py check`, `setup.py` was removed in #746.

## Are there changes in behavior for the user?

no

## Related issue number

fixes #756

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into `CHANGES.txt`