### PR TITLE
Checkout git source to access changelog for GitHub release creation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -739,6 +739,12 @@ jobs:
       discussions: write
 
     steps:
+    - name: Fetch the src snapshot
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        ref: ${{ github.event.inputs.release-commitish }}
+
     - name: Download all the dists
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
## What do these changes do?

Workflow was referencing `CHANGES.txt` for inclusion in GitHub release notes but it didn't check out the git repo for this.