### PR TITLE
Fix SSL connection handshake charset not respecting client configuration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 -------
 
+next (unreleased)
+^^^^^^^^^^^^^^^^^
+
+* Fix SSL connection handshake charset not respecting client configuration #776
+
 0.1.0 (2022-04-11)
 ^^^^^^^^^^^^^^^^^^
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -107,6 +107,20 @@ async def test_string(cursor, table_cleanup):
 
 
 @pytest.mark.run_loop
+async def test_string_with_emoji(cursor, table_cleanup):
+    await cursor.execute("DROP TABLE IF EXISTS test_string_with_emoji;")
+    await cursor.execute("CREATE TABLE test_string_with_emoji (a text) "
+                         "DEFAULT CHARACTER SET=\"utf8mb4\"")
+    test_value = "I am a test string with emoji 😄"
+    table_cleanup('test_string_with_emoji')
+    await cursor.execute("INSERT INTO test_string_with_emoji (a) VALUES (%s)",
+                         test_value)
+    await cursor.execute("SELECT a FROM test_string_with_emoji")
+    r = await cursor.fetchone()
+    assert (test_value,) == r
+
+
+@pytest.mark.run_loop
 async def test_integer(cursor, table_cleanup):
     await cursor.execute("CREATE TABLE test_integer (a INTEGER)")
     table_cleanup('test_integer')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The SSL connection handshake character set is fixed to utf8, this PR is to fix that issue #775

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Users should be able to establish SSL connections with the client charset parameter

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#775

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into `CHANGES.txt`