### PR TITLE
Skip codecov uploads in scheduled daily tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -611,6 +611,7 @@ jobs:
       timeout-minutes: 6
 
     - name: Upload coverage
+      if: ${{ github.event_name != 'schedule' }}
       uses: codecov/codecov-action@v3.1.0
       with:
         file: ./coverage.xml


### PR DESCRIPTION
## What do these changes do?

We can only upload a limited number of coverage reports for any commit anyway, this avoids turning these into test failures.

See e.g. https://github.com/aio-libs/aiomysql/runs/6143709548?check_suite_focus=true:

> [2022-04-24T01:46:32.439Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 400 - Bad Request - [ErrorDetail(string='Too many uploads to this commit.', code='invalid')]