### PR TITLE
XFail test_issue_36 for now to avoid failing for unrelated changes

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -255,7 +255,11 @@ async def test_issue_36(connection_creator):
     rows = await c.fetchall()
     ids = [row[0] for row in rows]
 
-    assert kill_id not in ids
+    try:
+        assert kill_id not in ids
+    except AssertionError:
+        # FIXME: figure out why this is failing
+        pytest.xfail("https://github.com/aio-libs/aiomysql/issues/714")
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
## What do these changes do?

Until we have a real fix for the sporadic test failures it's causing unrelated changes to randomly fail tests.
By xfailing with this condition random test failures from this are removed, #714 will stay open to properly resolve this in the future.

## Are there changes in behavior for the user?

no

## Related issue number

#714