### PR TITLE
Delay codecov notifications until reports from all matrix jobs have been received

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    after_n_builds: 40

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -398,6 +398,8 @@ jobs:
     - build
     - pre-setup  # transitive, for accessing settings
     strategy:
+      # when updating matrix jobs make sure to adjust the expected reports in
+      # codecov.notify.after_n_builds in .codecov.yml
       matrix:
         # service containers are only supported on ubuntu currently
         os:


### PR DESCRIPTION
While we do currently have 40 expected reports total it's probably not worth increasing the minimum to that, as this would have to be kept in mind whenever the number of matrix jobs changes.