### PR TITLE
Update mariadb tests to 10.8, remove end of life mariadb 10.2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -413,12 +413,12 @@ jobs:
         db:
         - [mysql, '5.7']
         - [mysql, '8.0']
-        - [mariadb, '10.2']
         - [mariadb, '10.3']
         - [mariadb, '10.4']
         - [mariadb, '10.5']
         - [mariadb, '10.6']
         - [mariadb, '10.7']
+        - [mariadb, '10.8']
 
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What do these changes do?

MariaDB 10.2 is no longer supported, remove it from from tests.
It's being replaced by MariaDB 10.8 in tests.