### PR TITLE
pin setuptools_scm < 7 due to broken builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools >= 42",
 
     # Plugins
-    "setuptools_scm[toml] >= 6.4",
+    "setuptools_scm[toml] >= 6.4, < 7",
     "setuptools_scm_git_archive >= 1.1",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## What do these changes do?

pin setuptools_scm < 7 due to broken builds.
in setuptools_scm version 7 the generated wheel version is wrong, needs to be investigated.

## Related issue number

#809