### PR TITLE
Fix MySQL 5.7 tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -584,13 +584,7 @@ jobs:
         # we need to ensure that the socket path is writable for the user running the DB process in the container
         sudo chmod 0777 /tmp/run-${{ join(matrix.db, '-') }}
 
-        # mysql 5.7 container overrides the socket path in /etc/mysql/mysql.conf.d/mysqld.cnf
-        if [ "${{ join(matrix.db, '-') }}" = "mysql-5.7" ]
-        then
-          docker container cp "${{ github.workspace }}/tests/ssl_resources/socket.cnf" mysqld:/etc/mysql/mysql.conf.d/zz-aiomysql-socket.cnf
-        else
-          docker container cp "${{ github.workspace }}/tests/ssl_resources/socket.cnf" mysqld:/etc/mysql/conf.d/aiomysql-socket.cnf
-        fi
+        docker container cp "${{ github.workspace }}/tests/ssl_resources/socket.cnf" mysqld:/etc/mysql/conf.d/aiomysql-socket.cnf
 
         docker container start mysqld
 


### PR DESCRIPTION
## What do these changes do?

The latest MySQL 5.7 images changed the default distro from debian to oracle linux.
With this change our tests are failing, as the path for the custom config to enable a unix socket no longer exists.
With this change we also no longer need to work around the config shipped in the container messing with out drop-in config in `/etc/mysql/conf.d/`, so we can remove the workaround for `mysql:5.7` and use the same logic for all database containers.

## Are there changes in behavior for the user?

no