### PR TITLE
Fix use of deprecated SQLAlchemy functionality in tests

### DIFF
--- a/tests/sa/test_sa_connection.py
+++ b/tests/sa/test_sa_connection.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from sqlalchemy import MetaData, Table, Column, Integer, String
+from sqlalchemy import MetaData, Table, Column, Integer, String, func, select
 from sqlalchemy.schema import DropTable, CreateTable
 from sqlalchemy.sql.expression import bindparam
 
@@ -130,7 +130,7 @@ async def test_execute_sa_insert_positional_params(sa_connect):
 @pytest.mark.run_loop
 async def test_scalar(sa_connect):
     conn = await sa_connect()
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res
 
 


### PR DESCRIPTION
## What do these changes do?

Fixes the following deprecation warning:
`SADeprecationWarning: The FromClause.count() method is deprecated, and will be removed in a future release.   Please use the count function available from the func namespace.`

References:
https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.count
https://docs.sqlalchemy.org/en/13/core/functions.html#sqlalchemy.sql.functions.count

## Are there changes in behavior for the user?

No, tests only.