### PR TITLE
Bump minimal SQLAlchemy version to 1.3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 -------
 
+next (unreleased)
+^^^^^^^^^^^^^^^^^^
+
+* Bump minimal SQLAlchemy version to 1.3 #815
+
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
 
 [options.extras_require]
 sa =
-  sqlalchemy>=1.0,<1.4
+  sqlalchemy>=1.3,<1.4
 rsa =
   PyMySQL[rsa]>=1.0
 


### PR DESCRIPTION
## What do these changes do?

Bump minimal SQLAlchemy version to 1.3.
According to https://www.sqlalchemy.org/download.html all older versions are EOL, 1.3 is still in maintenance state.

## Are there changes in behavior for the user?

`aiomysql[sa]` now requires SQLAlchemy version 1.3.

## Checklist

- [x] Documentation reflects the changes
- [x] Add a new news fragment into `CHANGES.txt`