### PR TITLE
ci: increase pytest timeout to 9.5 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -601,11 +601,11 @@ jobs:
     - name: Run tests
       run: |
         # timeout ensures a more or less clean stop by sending a KeyboardInterrupt which will still provide useful logs
-        timeout --preserve-status --signal=INT --verbose 5m \
+        timeout --preserve-status --signal=INT --verbose 570s \
           pytest --capture=no --verbosity 2 --cov-report term --cov-report xml --cov aiomysql --cov tests ./tests --mysql-unix-socket "unix-${{ join(matrix.db, '') }}=/tmp/run-${{ join(matrix.db, '-') }}/mysql.sock" --mysql-address "tcp-${{ join(matrix.db, '') }}=127.0.0.1:3306"
       env:
         PYTHONUNBUFFERED: 1
-      timeout-minutes: 6
+      timeout-minutes: 10
 
     - name: Upload coverage
       if: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
## What do these changes do?

Increase pytest timeout to 9.5 minutes (SIGINT), 10 minutes max in CI workflow.

Some runners appear to be very slow.

This will hopefully avoid failures like https://github.com/aio-libs/aiomysql/actions/runs/2642476373/attempts/1 in the future-

## Are there changes in behavior for the user?

no