### PR TITLE
catch another warning in tests

### DIFF
--- a/tests/test_sscursor.py
+++ b/tests/test_sscursor.py
@@ -196,7 +196,11 @@ async def test_sscursor_discarded_result(connection):
     await _prepare(conn)
     async with conn.cursor(SSCursor) as cursor:
         await cursor.execute("select 1")
-        await cursor.execute("select 2")
+        with pytest.warns(
+            UserWarning,
+            match="Previous unbuffered result was left incomplete",
+        ):
+            await cursor.execute("select 2")
         ret = await cursor.fetchone()
     assert (2,) == ret
 
@@ -262,7 +266,10 @@ async def test_max_execution_time(mysql_server, connection):
 
         # this discards the previous unfinished query and raises an
         # incomplete unbuffered query warning
-        with pytest.warns(UserWarning):
+        with pytest.warns(
+            UserWarning,
+            match="Previous unbuffered result was left incomplete",
+        ):
             await cur.execute("SELECT 1")
         assert (await cur.fetchone()) == (1,)
 


### PR DESCRIPTION
## What do these changes do?

Catch another warning in tests, so we have one less uncaught warning.
Also adjusts another instance of the same warning in the test to be more specific about which warning to catch.

## Are there changes in behavior for the user?

no