### PR TITLE
chore: update CI/CD readme badge to reflect schedule builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 aiomysql
 ========
-.. image:: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml/badge.svg?branch=master
+.. image:: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml/badge.svg?branch=master&event=schedule
     :target: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml?query=event%3Aschedule
 .. image:: https://codecov.io/gh/aio-libs/aiomysql/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiomysql

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aiomysql
 ========
 .. image:: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml/badge.svg?branch=master
-    :target: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml
+    :target: https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml?query=event%3Aschedule
 .. image:: https://codecov.io/gh/aio-libs/aiomysql/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiomysql
     :alt: Code coverage


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Updating CI/CD tests badge to only reflect only the daily `schedule` event build.
 
Right now the badge reflects the latest build for any event trigger (pull_request, schedule, push). This means a failing `pull_request` build from an open PR will change the README CI/CD badge to be red and display "failing". (See below)

![image](https://user-images.githubusercontent.com/32113413/180876951-bfd376b3-03db-4016-aafd-893469a926c6.png)

I've update the badge to point to the following [scheduled builds](https://github.com/aio-libs/aiomysql/actions/workflows/ci-cd.yml?query=event%3Aschedule) which will reflect the current changes in master at any given time.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No changes.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
No issue.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
