### PR TITLE
Partially port PyMySQL#304

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ next (unreleased)
 
 * Remove deprecated Pool.get #706
 
+* | Partially ported `PyMySQL#304 <https://github.com/PyMySQL/PyMySQL/pull/304>`_ #792
+  | aiomysql now reraises the original exception during connect() if it's not `IOError`, `OSError` or `asyncio.TimeoutError`.
+  | This was previously always raised as `OperationalError`.
+
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -26,7 +26,8 @@ def fill_my_cnf(mysql_params):
 
 @pytest.mark.run_loop
 async def test_connect_timeout(connection_creator):
-    # All exceptions are caught and raised as operational errors
+    # OSErrors and asyncio.TimeoutError are caught and raised as operational
+    # errors
     with pytest.raises(aiomysql.OperationalError):
         await connection_creator(connect_timeout=0.000000000001)
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -465,3 +465,13 @@ async def test_issue_323(mysql_server, loop, recwarn):
             finally:
                 async with conn.cursor() as cur:
                     await cur.execute("DELETE FROM `bugtest`.`testtable`;")
+
+
+# https://github.com/aio-libs/aiomysql/issues/792
+@pytest.mark.run_loop
+async def test_issue_792(connection_creator):
+    with pytest.raises(aiomysql.OperationalError) as exc_info:
+        await connection_creator(db="does_not_exist")
+
+    assert exc_info.value.args[0] == 1049
+    assert exc_info.value.args[1] == "Unknown database 'does_not_exist'"


### PR DESCRIPTION
## What do these changes do?

Partially port https://github.com/PyMySQL/PyMySQL/pull/304

## Are there changes in behavior for the user?

aiomysql now reraises the original exception during connect() if it's not `IOError`, `OSError` or `asyncio.TimeoutError`.
This was previously always raised as `OperationalError`.

`asyncio.TimeoutError` is a deprecated alias of `OSError` as of python 3.11, for consistency we already include here, so the exception handling won't differ across python versions.

## Related issue number

fixes #792

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into `CHANGES.txt`