### PR TITLE
Fix log exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ next (unreleased)
   | aiomysql now reraises the original exception during connect() if it's not `IOError`, `OSError` or `asyncio.TimeoutError`.
   | This was previously always raised as `OperationalError`.
 
+* Fix debug log level with sha256_password authentication #863
+
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -1010,7 +1010,7 @@ class Connection:
         if pkt.is_extra_auth_data():
             self.server_public_key = pkt._data[1:]
             logger.debug(
-                "Received public key:\n",
+                "Received public key:\n%s",
                 self.server_public_key.decode('ascii')
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix log exception, when login mysql using sha256_password_auth, exception throw 
`TypeError: not all arguments converted during string formatting` at `connection.py:1012` 
```
            logger.debug(
                "Received public key:\n",
                self.server_public_key.decode('ascii')
            )
```

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
