### PR TITLE
Update build-system requirements of setuptools-scm to >= 7.0.5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ next (unreleased)
 
 * Fix debug log level with sha256_password authentication #863
 
+* Update build-system requirements to drop the use of setuptools-scm-git-archive #872
+
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 requires = [
     # Essentials
-    "setuptools >= 42",
+    "setuptools >= 45",
 
     # Plugins
-    "setuptools_scm[toml] >= 6.4, < 7",
-    "setuptools_scm_git_archive >= 1.1",
+    "setuptools_scm[toml] >=7.0.5",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Increase the build-system requirements of setuptools-scm to >= 7.0.5, which obsoletes setuptools-scm-git-archive.
Issues around the use of setuptools-scm as discussed in https://github.com/aio-libs/aiomysql/issues/809 and https://github.com/pypa/setuptools_scm/issues/745
have been fixed in
https://github.com/pypa/setuptools_scm/commit/b7c0d0d04cd7fdd761eabcd3d16ce18b12d458d7 and relesed with
https://github.com/pypa/setuptools_scm/releases/tag/v7.0.5

<!-- Thank you for your contribution! -->

## What do these changes do?

Increase the build-system requirements of setuptools-scm to >= 7.0.5, which obsoletes setuptools-scm-git-archive.

## Are there changes in behavior for the user?

setuptools-scm-git-archive is no longer required during build time.

## Related issue number
https://github.com/aio-libs/aiomysql/issues/809 
https://github.com/pypa/setuptools_scm/issues/745

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
