### PR TITLE
Stop dependabot from autoamtically rebasing PRs to save CI time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   target-branch: master
+  rebase-strategy: disabled  # Automatic rebases are disabled to save CI time
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  rebase-strategy: disabled  # Automatic rebases are disabled to save CI time


### PR DESCRIPTION
## What do these changes do?

When multiple PRs are open this can quickly add up to lots of time consuming CI runs.
Dependabot previously rebased every time a new commit was added to master, as an updated CI run is required for PR merging.