### PR TITLE
Bring flake8 version in GitHub actions in sync with requirements-dev.txt

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -377,7 +377,7 @@ jobs:
     - name: flake8 Lint
       uses: py-actions/flake8@v2.2.1
       with:
-        flake8-version: 4.0.1
+        flake8-version: 5.0.4
         path: aiomysql
         args: tests examples
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage==6.5.0
+# flake8 version is also specified in .github/workflows/ci-cd.yml
 flake8==5.0.4
 ipdb==0.13.13
 pytest==7.3.1


### PR DESCRIPTION
## What do these changes do?

Bring flake8 version in GitHub actions in sync with requirements-dev.txt.
Previously, GitHub actions would use an earlier version than dev requirements for local testing.