### PR TITLE
Implement Trusted Publishing for prod PyPI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -653,6 +653,9 @@ jobs:
           needs.pre-setup.outputs.dist-version
         }}
 
+    permissions:
+      id-token: write  # this permission is mandatory for trusted publishing
+
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v3
@@ -663,7 +666,6 @@ jobs:
         Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
         print_hash: true
 
   publish-testpypi:


### PR DESCRIPTION
## What do these changes do?

Implement OIDC-based publishing to PyPI: https://docs.pypi.org/trusted-publishers/

This avoids having to use long lived secrets by replacing them with GitHub-issued OIDC tokens generated on demand.

Publishing for Test PyPI has been implemented in #929 already.