### PR TITLE
Add pre-commit config for pyupgrade --py37-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.4.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]


### PR DESCRIPTION
## What do these changes do?

Add [pre-commit](https://pre-commit.com/) config for [pyupgrade](https://github.com/asottile/pyupgrade).

This also allows using the [pre-commit.ci](https://pre-commit.ci/) PR integration.

## Are there changes in behavior for the user?

No, optional helper for aiomysql developers.