### PR TITLE
Test only and all supported MariaDB versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -413,12 +413,12 @@ jobs:
         db:
         - [mysql, '5.7']
         - [mysql, '8.0']
-        - [mariadb, '10.3']
         - [mariadb, '10.4']
         - [mariadb, '10.5']
         - [mariadb, '10.6']
-        - [mariadb, '10.7']
-        - [mariadb, '10.8']
+        - [mariadb, '10.9']
+        - [mariadb, '10.10']
+        - [mariadb, '10.11']
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ next (unreleased)
 
 * Modernized code with `pyupgrade <https://github.com/asottile/pyupgrade>`_ to Python 3.7+ syntax #930
 
+* Removed tests for EoL MariaDB versions 10.3, 10.7 and 10.8, added tests for MariaDB 10.9, 10.10, 10.11 #932
+
 0.1.1 (2022-05-08)
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## What do these changes do?

Remove tests for EoL MariaDB versions 10.3, 10.7 and 10.8, added tests for MariaDB 10.9, 10.10, 10.11.

## Are there changes in behavior for the user?

EoL MariaDB versions are no longer tested and may no longer work.

## Related issue number

\-

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment to `CHANGES.txt`