### PR TITLE
Migrate GHA pypi publish action inputs to kebab-case

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -682,7 +682,7 @@ jobs:
         Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        print_hash: true
+        print-hash: true
 
   publish-testpypi:
     name: Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to TestPyPI
@@ -714,8 +714,8 @@ jobs:
         Publish 🐍📦 ${{ needs.pre-setup.outputs.git-tag }} to TestPyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        repository_url: https://test.pypi.org/legacy/
-        print_hash: true
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
 
   post-release-repo-update:
     name: >-


### PR DESCRIPTION
## What do these changes do?

Change pypa/gh-action-pypi-publish action input names to kebab-case.

As of [v1.7.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0), [pypi-publish](https://github.com/marketplace/actions/pypi-publish) uses kebab-case for input namings.
While snake_case names are still supported, they're now generating warnings
and will eventually be removed.

## Are there changes in behavior for the user?

No, only CI workflow.