### PR TITLE
Add typed namedtuple `Description`

### DIFF
--- a/aiomysql/_type.py
+++ b/aiomysql/_type.py
@@ -1,0 +1,18 @@
+from typing import NamedTuple, Optional
+
+
+class Description(NamedTuple):
+    #: the name of the column returned.
+    name: str
+    #: the type of the column.
+    type_code: int
+    #: the actual length of the column in bytes.
+    display_size: Optional[int]
+    #: the size in bytes of the column associated to this column on the server.
+    internal_size: int
+    #: total number of significant digits in columns of type NUMERIC. None for other types.
+    precision: Optional[int]
+    #: count of decimal digits in the fractional part in columns of type NUMERIC. None for other types.
+    scale: Optional[int]
+    #: always None as not easy to retrieve from the libpq.
+    null_ok: Optional[bool]

--- a/aiomysql/_type.py
+++ b/aiomysql/_type.py
@@ -10,9 +10,11 @@ class Description(NamedTuple):
     display_size: Optional[int]
     #: the size in bytes of the column associated to this column on the server.
     internal_size: int
-    #: total number of significant digits in columns of type NUMERIC. None for other types.
+    #: total number of significant digits in columns of type NUMERIC.
+    #: None for other types.
     precision: Optional[int]
-    #: count of decimal digits in the fractional part in columns of type NUMERIC. None for other types.
+    #: count of decimal digits in the fractional part in columns of type NUMERIC.
+    #: None for other types.
     scale: Optional[int]
     #: always None as not easy to retrieve from the libpq.
     null_ok: Optional[bool]

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -34,6 +34,7 @@ from pymysql.connections import EOFPacketWrapper
 from pymysql.connections import OKPacketWrapper
 from pymysql.connections import LoadLocalPacketWrapper
 
+from ._type import Description
 # from aiomysql.utils import _convert_to_str
 from .cursors import Cursor
 from .utils import _pack_int24, _lenenc_int, _ConnectionContextManager, _ContextManager
@@ -1317,7 +1318,7 @@ class MySQLResult:
             field = await self.connection._read_packet(
                 FieldDescriptorPacket)
             self.fields.append(field)
-            description.append(field.description())
+            description.append(Description(*field.description()))
             field_type = field.type_code
             if use_unicode:
                 if field_type == FIELD_TYPE.JSON:

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -59,7 +59,7 @@ class Cursor:
     def description(self):
         """This read-only attribute is a sequence of 7-item sequences.
 
-        Each of these sequences is a collections.namedtuple containing
+        Each of these sequences is a tuple containing
         information describing one result column:
 
         0.  name: the name of the column returned.

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -58,7 +58,7 @@ class Cursor:
         return self._connection
 
     @property
-    def description(self) -> t.Optional[t.Tuple[Description, ...]]:
+    def description(self) -> t.Optional[t.Sequence[Description]]:
         """This read-only attribute is a sequence of 7-item sequences.
 
         This attribute will be None for operations that do not

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -7,9 +7,14 @@ from pymysql.err import (
     Warning, Error, InterfaceError, DataError,
     DatabaseError, OperationalError, IntegrityError, InternalError,
     NotSupportedError, ProgrammingError)
+import typing as t
 
+from ._type import Description
 from .log import logger
 from .connection import FIELD_TYPE
+
+if t.TYPE_CHECKING:
+    from .connection import Connection
 
 # https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/cursors.py#L11-L18
 
@@ -33,7 +38,7 @@ class Cursor:
     #: Default value of max_allowed_packet is 1048576.
     max_stmt_length = 1024000
 
-    def __init__(self, connection, echo=False):
+    def __init__(self, connection: 'Connection', echo: bool = False) -> None:
         """Do not create an instance of a Cursor yourself. Call
         connections.Connection.cursor().
         """
@@ -50,28 +55,14 @@ class Cursor:
         self._echo = echo
 
     @property
-    def connection(self):
+    def connection(self) -> 'Connection':
         """This read-only attribute return a reference to the Connection
         object on which the cursor was created."""
         return self._connection
 
     @property
-    def description(self):
+    def description(self) -> t.Optional[t.Tuple[Description]]:
         """This read-only attribute is a sequence of 7-item sequences.
-
-        Each of these sequences is a tuple containing
-        information describing one result column:
-
-        0.  name: the name of the column returned.
-        1.  type_code: the type of the column.
-        2.  display_size: the actual length of the column in bytes.
-        3.  internal_size: the size in bytes of the column associated to
-            this column on the server.
-        4.  precision: total number of significant digits in columns of
-            type NUMERIC. None for other types.
-        5.  scale: count of decimal digits in the fractional part in
-            columns of type NUMERIC. None for other types.
-        6.  null_ok: always None as not easy to retrieve from the libpq.
 
         This attribute will be None for operations that do not
         return rows or if the cursor has not had an operation invoked

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -58,7 +58,7 @@ class Cursor:
         return self._connection
 
     @property
-    def description(self) -> t.Optional[t.Tuple[Description]]:
+    def description(self) -> t.Optional[t.Tuple[Description, ...]]:
         """This read-only attribute is a sequence of 7-item sequences.
 
         This attribute will be None for operations that do not

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -35,7 +35,7 @@ class Cursor:
     #: Default value of max_allowed_packet is 1048576.
     max_stmt_length = 1024000
 
-    def __init__(self, connection, echo: bool = False) -> None:
+    def __init__(self, connection, echo=False):
         """Do not create an instance of a Cursor yourself. Call
         connections.Connection.cursor().
         """

--- a/aiomysql/cursors.py
+++ b/aiomysql/cursors.py
@@ -13,9 +13,6 @@ from ._type import Description
 from .log import logger
 from .connection import FIELD_TYPE
 
-if t.TYPE_CHECKING:
-    from .connection import Connection
-
 # https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/cursors.py#L11-L18
 
 #: Regular expression for :meth:`Cursor.executemany`.
@@ -38,7 +35,7 @@ class Cursor:
     #: Default value of max_allowed_packet is 1048576.
     max_stmt_length = 1024000
 
-    def __init__(self, connection: 'Connection', echo: bool = False) -> None:
+    def __init__(self, connection, echo: bool = False) -> None:
         """Do not create an instance of a Cursor yourself. Call
         connections.Connection.cursor().
         """
@@ -55,7 +52,7 @@ class Cursor:
         self._echo = echo
 
     @property
-    def connection(self) -> 'Connection':
+    def connection(self):
         """This read-only attribute return a reference to the Connection
         object on which the cursor was created."""
         return self._connection

--- a/docs/cursors.rst
+++ b/docs/cursors.rst
@@ -64,7 +64,7 @@ Cursor
 
         This read-only attribute is a sequence of 7-item sequences.
 
-        Each of these sequences is a collections.namedtuple containing
+        Each of these sequences is a tuple containing
         information describing one result column:
 
         0.  name: the name of the column returned.

--- a/docs/cursors.rst
+++ b/docs/cursors.rst
@@ -64,7 +64,7 @@ Cursor
 
         This read-only attribute is a sequence of 7-item sequences.
 
-        Each of these sequences is a tuple containing
+        Each of these sequences is a collections.namedtuple containing
         information describing one result column:
 
         0.  name: the name of the column returned.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
add a `class Description(typing.NamedTuple)` for cursor.description

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
yes, `cursor.description` now return a `tuple[Description]` instead of `tuple[tuple[...]]`
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
