### PR TITLE
Bump minimum Python version to 3.9, test up to 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,11 +65,11 @@ jobs:
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
     steps:
-    - name: Switch to using Python 3.10 by default
+    - name: Switch to using Python 3.13 by default
       uses: actions/setup-python@v6
       with:
         python-version: >-
-          3.10
+          3.13
     - name: >-
         Mark the build as untagged '${{
             github.event.repository.default_branch
@@ -199,11 +199,11 @@ jobs:
       PY_COLORS: 1
 
     steps:
-    - name: Switch to using Python v3.10
+    - name: Switch to using Python v3.13
       uses: actions/setup-python@v6
       with:
         python-version: >-
-          3.10
+          3.13
     - name: Set up pip cache
       uses: re-actors/cache-python-deps@810325a232f2a28ea124dfba85c7c72fd1774b38 # v1.0.0
       with:
@@ -287,11 +287,11 @@ jobs:
       PY_COLORS: 1
 
     steps:
-    - name: Switch to using Python 3.10 by default
+    - name: Switch to using Python 3.13 by default
       uses: actions/setup-python@v6
       with:
         python-version: >-
-          3.10
+          3.13
     - name: Set up pip cache
       uses: re-actors/cache-python-deps@810325a232f2a28ea124dfba85c7c72fd1774b38 # v1.0.0
       with:
@@ -348,10 +348,11 @@ jobs:
         os:
         - ubuntu-latest
         py:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
+        - '3.13'
         db:
         - [mysql, '5.7']
         - [mysql, '8.0']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v3.4.0
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py39-plus]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 -------
 
+next (unreleased)
+^^^^^^^^^^^^^^^^^^
+
+* Drop support for Python 3.7 and 3.8, replaced by 3.12 and 3.13
+
 0.2.0 (2023-06-11)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ next (unreleased)
 
 * Drop support for Python 3.7 and 3.8, replaced by 3.12 and 3.13
 
+* Bump minimum Sphinx version to generate documentation to 6.2.0 for Python 3.13 support
+
 0.2.0 (2023-06-11)
 ^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ for aiopg_ user.:
 Requirements
 ------------
 
-* Python_ 3.7+
+* Python_ 3.9+
 * PyMySQL_
 
 

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 import socket
 import struct
-import sys
 import warnings
 import configparser
 import getpass
@@ -188,7 +187,7 @@ class Connection:
         """
         self._loop = loop or asyncio.get_event_loop()
 
-        if use_unicode is None and sys.version_info[0] > 2:
+        if use_unicode is None:
             use_unicode = True
 
         if read_default_file:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,7 @@ coverage reports.
 Dependencies
 ------------
 
-- Python 3.7+
+- Python 3.9+
 - :term:`PyMySQL`
 - aiomysql.sa requires :term:`sqlalchemy`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,17 @@ authors = [
 ]
 description = "MySQL driver for asyncio."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = ["mysql", "mariadb", "asyncio", "aiomysql"]
 license = "MIT"
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX",
     "Environment :: Web Environment",
     "Development Status :: 3 - Alpha",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest==7.3.2
 pytest-cov==4.1.0
 pytest-sugar==0.9.7
 PyMySQL==1.0.3
-sphinx>=1.8.1, <5.1.2
+sphinx>=6.2.0, <9.0.0
 sphinxcontrib-asyncio==0.3.0
 SQLAlchemy==1.3.24
 uvloop==0.21.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ PyMySQL==1.0.3
 sphinx>=1.8.1, <5.1.2
 sphinxcontrib-asyncio==0.3.0
 SQLAlchemy==1.3.24
-uvloop==0.17.0
-twine==6.2.0; python_version > '3.8'
+uvloop==0.21.0
+twine==6.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ def table_cleanup(loop, connection):
     yield _register_table
     for t in table_list:
         # TODO: probably this is not safe code
-        sql = f"DROP TABLE IF EXISTS {t};"
+        sql = f"DROP TABLE IF EXISTS {t}"
         loop.run_until_complete(cursor.execute(sql))
 
 


### PR DESCRIPTION
## What do these changes do?

Drop support for Python versions older than 3.9.

## Are there changes in behavior for the user?

`requires-python` has been updated, therefore newer releases won't be installed on versions below 3.9.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
