### PR TITLE
Update MySQL and MariaDB to supported versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -356,14 +356,14 @@ jobs:
         - '3.12'
         - '3.13'
         db:
-        - [mysql, '5.7']
         - [mysql, '8.0']
-        - [mariadb, '10.4']
-        - [mariadb, '10.5']
+        - [mysql, '8.4']
+        - [mysql, '9.4']
         - [mariadb, '10.6']
-        - [mariadb, '10.9']
-        - [mariadb, '10.10']
         - [mariadb, '10.11']
+        - [mariadb, '11.4']
+        - [mariadb, '11.8']
+        - [mariadb, '12.0']
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,10 @@ next (unreleased)
 
 * Sphinx now uses the furo theme for local and RTD builds
 
+* Drop support for EoL MySQL 5.7, replaced by 8.4 and 9.4
+
+* Drop support for EoL MariaDB 10.4, 10.5, 10.9, 10.10, replaced by 11.4, 11.8, 12.0
+
 0.2.0 (2023-06-11)
 ^^^^^^^^^^^^^^^^^^
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 mysql:
-    image: mysql:5.7
+    image: mysql:8.4
     environment:
         - MYSQL_USER=aiomysql
         - MYSQL_PASSWORD=mypass

--- a/docs/sa.rst
+++ b/docs/sa.rst
@@ -602,7 +602,7 @@ Transaction objects
      .. seealso::  `SAVEPOINT, ROLLBACK TO SAVEPOINT, and RELEASE SAVEPOINT`__
           on :term:`MySQL`:
 
-    .. __: http://dev.mysql.com/doc/refman/5.7/en/savepoint.html
+    .. __: https://dev.mysql.com/doc/refman/8.4/en/savepoint.html
 
 
 .. class:: TwoPhaseTransaction
@@ -629,4 +629,4 @@ Transaction objects
 
     .. seealso:: :term:`MySQL` commands for two phase transactions:
 
-        http://dev.mysql.com/doc/refman/5.7/en/xa-statements.html
+        https://dev.mysql.com/doc/refman/8.4/en/xa-statements.html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,17 +282,7 @@ def mysql_server(mysql_address):
                                           server_version_tuple[1])
 
             if not unix_socket:
-                cursor.execute("SHOW VARIABLES LIKE '%ssl%';")
-
-                result = cursor.fetchall()
-                result = {item['Variable_name']:
-                          item['Value'] for item in result}
-
-                assert result['have_ssl'] == "YES", \
-                    "SSL Not Enabled on MySQL"
-
                 cursor.execute("SHOW STATUS LIKE 'Ssl_version%'")
-
                 result = cursor.fetchone()
                 # As we connected with TLS, it should start with that :D
                 assert result['Value'].startswith('TLS'), \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,7 @@ def mysql_server(mysql_address):
         with connection.cursor() as cursor:
             cursor.execute("SELECT VERSION() AS version")
             server_version = cursor.fetchone()["version"]
+            db_type = "mariadb" if "MariaDB" in server_version else "mysql"
             server_version_tuple = tuple(
                 (int(dig) if dig is not None else 0)
                 for dig in
@@ -279,13 +280,6 @@ def mysql_server(mysql_address):
             )
             server_version_tuple_short = (server_version_tuple[0],
                                           server_version_tuple[1])
-            if server_version_tuple_short in [(5, 7), (8, 0)]:
-                db_type = "mysql"
-            elif server_version_tuple[0] == 10:
-                db_type = "mariadb"
-            else:
-                pytest.fail("Unable to determine database type from {!r}"
-                            .format(server_version_tuple))
 
             if not unix_socket:
                 cursor.execute("SHOW VARIABLES LIKE '%ssl%';")


### PR DESCRIPTION
## What do these changes do?

- Drop support for EoL MySQL 5.7, replaced by 8.4 and 9.4
- Drop support for EoL MariaDB 10.4, 10.5, 10.9, 10.10, replaced by 11.4, 11.8, 12.0

## Are there changes in behavior for the user?

Only tests have been changed for now.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
