### PR TITLE
Publish immutable GitHub releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -741,3 +741,4 @@ jobs:
         discussionCategory: Announcements
         name: ${{ needs.pre-setup.outputs.git-tag }}
         tag: ${{ needs.pre-setup.outputs.git-tag }}
+        immutableCreate: true

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ next (unreleased)
 
 * Drop support for EoL MariaDB 10.4, 10.5, 10.9, 10.10, replaced by 11.4, 11.8, 12.0
 
+* Use immutable GitHub tags and releases for future releases
+
 0.2.0 (2023-06-11)
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## What do these changes do?

Future GitHub releases will be immutable, this changes the way releases are published to allow immutability.