### PR TITLE
Bump flake8 to 7.3.0

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -337,7 +337,7 @@ jobs:
     - name: flake8 Lint
       uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2.3.0
       with:
-        flake8-version: 5.0.4
+        flake8-version: 7.3.0
         path: aiomysql
         args: tests examples
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==7.10.6
 # flake8 version is also specified in .github/workflows/ci-cd.yml
-flake8==5.0.4
+flake8==7.3.0
 ipdb==0.13.13
 pytest==8.4.2
 pytest-cov==7.0.0

--- a/tests/sa/test_sa_default.py
+++ b/tests/sa/test_sa_default.py
@@ -78,7 +78,7 @@ async def test_default_fields(make_engine):
         assert row.number == 100
         assert row.description == 'default test'
         assert row.enabled is True
-        assert type(row.created_at) == datetime.datetime
+        assert isinstance(row.created_at, datetime.datetime)
 
 
 @pytest.mark.run_loop

--- a/tests/test_dictcursor.py
+++ b/tests/test_dictcursor.py
@@ -103,5 +103,5 @@ async def test_ssdictcursor(connection):
     c = await conn.cursor(aiomysql.cursors.SSDictCursor)
     await c.execute("SELECT * from dictcursor where name='bob'")
     r = await c.fetchall()
-    assert [BOB] == r,\
+    assert [BOB] == r, \
         "fetch a 1 row result via fetchall failed via DictCursor"


### PR DESCRIPTION
## What do these changes do?

Update the flake8 linter.
This also adjusts two tests to address lints for E231 and E721

## Are there changes in behavior for the user?

no

closes #874