### PR TITLE
Fix arbitrary file access vulnerability when connecting to malicious servers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,11 @@ next (unreleased)
 * | Bump setuptools to >=80, setuptools-scm to  >=7, <10.
   | setuptools-scm must be at least 9.2.0 for consistent hash lengths of non-release builds.
 
+* | Properly check whether loading of local files is enabled #1044
+  | Loading local data now requires using the `local_infile` parameter, passing just the client flag through `client_flag` is no longer supported.
+  | Fixes `GHSA-r397-ff8c-wv2g <https://github.com/aio-libs/aiomysql/security/advisories/GHSA-r397-ff8c-wv2g>`_
+  | Thanks to @KonstantAnxiety for reporting this.
+
 0.2.0 (2023-06-11)
 ^^^^^^^^^^^^^^^^^^
 

--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -245,7 +245,8 @@ class Connection:
 
         self._encoding = charset_by_name(self._charset).encoding
 
-        if local_infile:
+        self._local_infile = bool(local_infile)
+        if self._local_infile:
             client_flag |= CLIENT.LOCAL_FILES
 
         client_flag |= CLIENT.CAPABILITIES
@@ -1203,6 +1204,10 @@ class MySQLResult:
         self.has_next = ok_packet.has_next
 
     async def _read_load_local_packet(self, first_packet):
+        if not self.connection._local_infile:
+            raise RuntimeError(
+                "**WARN**: Received LOAD_LOCAL packet but local_infile option is false."
+            )
         load_packet = LoadLocalPacketWrapper(first_packet)
         sender = LoadLocalFile(load_packet.filename, self.connection)
         try:

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -46,8 +46,8 @@ Example::
             client_flag=0, cursorclass=Cursor, init_command=None,
             connect_timeout=None, read_default_group=None,
             autocommit=False, echo=False
-            ssl=None, auth_plugin='', program_name='',
-            server_public_key=None, loop=None)
+            local_infile=False, loop=None, ssl=None, auth_plugin='',
+            program_name='', server_public_key=None)
 
     A :ref:`coroutine <coroutine>` that connects to MySQL.
 
@@ -71,7 +71,8 @@ Example::
         See `pymysql.converters`.
     :param use_unicode: whether or not to default to unicode strings.
     :param  client_flag: custom flags to send to MySQL. Find
-        potential values in `pymysql.constants.CLIENT`.
+        potential values in `pymysql.constants.CLIENT`. Refer to the
+        `local_infile` parameter for enabling loading of local data.
     :param cursorclass: custom cursor class to use.
     :param str init_command: initial SQL statement to run when connection is
         established.
@@ -81,6 +82,10 @@ Example::
         file.
     :param autocommit: Autocommit mode. None means use server default.
         (default: ``False``)
+    :param local_infile: Boolean to enable the use of `LOAD DATA LOCAL`
+        command. This also enables the corresponding `client_flag`. aiomysql
+        does not perform any validation of files requested by the server. Do
+        not use this with untrusted servers. (default: ``False``)
     :param ssl: Optional SSL Context to force SSL
     :param auth_plugin: String to manually specify the authentication
         plugin to use, i.e you will want to use mysql_clear_password


### PR DESCRIPTION
## What do these changes do?

Properly check whether the server is allowed to request local files.

## Are there changes in behavior for the user?

Loading local data now requires using the `local_infile` parameter, passing just the client flag through `client_flag` is no longer supported.

## Related issue number

GHSA-r397-ff8c-wv2g

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
