### PR TITLE
Revert not persisting GitHub credentials in workflow job for pushing a Git tag after release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -676,7 +676,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         show-progress: false
-        persist-credentials: false
+        persist-credentials: true
         fetch-depth: 1
         ref: ${{ github.event.inputs.release-commitish }}
     - name: Setup git user as [bot]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 -------
 
+0.3.2 (2025-10-21)
+^^^^^^^^^^^^^^^^^^
+
+* Fix not persisting GitHub credentials during Git checkout action in CI for publishing release tags #1047
+
 0.3.1 (2025-10-21)
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This was broken in b3f50b04e2d708c9eb7a72a0937629e9f6305faa.