### PR TITLE
fix: catch OSError from getpass.getuser on Python 3.13+

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -40,7 +40,7 @@ from .log import logger
 
 try:
     DEFAULT_USER = getpass.getuser()
-except KeyError:
+except (KeyError, OSError):
     DEFAULT_USER = "unknown"
 
 


### PR DESCRIPTION
Python 3.13 changed getpass.getuser() to raise OSError instead of KeyError when no username is set. This causes aiomysql to crash on import in containerized environments. Catch both exceptions to match the upstream PyMySQL fix.

Closes #1053