### PR TITLE
fix: handle OSError from getpass.getuser on Python 3.13+

### DIFF
--- a/aiomysql/connection.py
+++ b/aiomysql/connection.py
@@ -40,7 +40,7 @@ from .log import logger
 
 try:
     DEFAULT_USER = getpass.getuser()
-except KeyError:
+except (KeyError, OSError):
     DEFAULT_USER = "unknown"
 
 


### PR DESCRIPTION
## Summary

Python 3.13 changed `getpass.getuser()` to raise `OSError` instead of `KeyError` when the UID has no matching username entry (e.g. in containers with numeric UIDs, see [bpo-32731](https://bugs.python.org/issue32731)). The current code only catches `KeyError`, so importing aiomysql crashes on Python 3.13+ in such environments.

This mirrors the fix applied to PyMySQL in PyMySQL/PyMySQL@a1ac823.

## Details

**Before:** Import fails with `OSError` on Python 3.13+ when UID is unmapped
**After:** Gracefully falls back to `"unknown"` user, same as the existing KeyError path

Fixes #1053