### PR TITLE
Exclude docs and examples from the published package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = "setuptools.build_meta"
 platforms = ["POSIX"]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+exclude = ["docs", "docs.*", "examples", "examples.*", "tests", "tests.*"]
 
 [tool.setuptools_scm]
 write_to = "aiomysql/_scm_version.py"


### PR DESCRIPTION
Fixes #1051

Excludes `docs/` and `examples/` from the published package so they are not installed as top-level site-packages.